### PR TITLE
Cross Out Role Outline

### DIFF
--- a/client/src/game/gameManager.d.tsx
+++ b/client/src/game/gameManager.d.tsx
@@ -75,6 +75,7 @@ export type GameManager = {
     sendDayTargetPacket(targetIndex: number): void;
     sendSaveWillPacket(will: string): void;
     sendSaveNotesPacket(notes: string): void;
+    sendSaveCrossedOutOutlinesPacket(crossedOutOutlines: number[]): void;
     sendSaveDeathNotePacket(notes: string): void;
     sendSendMessagePacket(text: string): void;
     sendSendWhisperPacket(playerIndex: number, text: string): void;

--- a/client/src/game/gameManager.tsx
+++ b/client/src/game/gameManager.tsx
@@ -291,6 +291,12 @@ export function createGameManager(): GameManager {
                 notes: notes
             });
         },
+        sendSaveCrossedOutOutlinesPacket(crossedOutOutlines) {
+            this.server.sendPacket({
+                type: "saveCrossedOutOutlines",
+                crossedOutOutlines: crossedOutOutlines
+            });
+        },
         sendSaveDeathNotePacket(notes) {
             this.server.sendPacket({
                 type: "saveDeathNote",

--- a/client/src/game/gameState.d.tsx
+++ b/client/src/game/gameState.d.tsx
@@ -56,6 +56,7 @@ type GameState = {
 
     will: string,
     notes: string,
+    crossedOutOutlines: number[],
     deathNote: string,
     targets: PlayerIndex[],
     voted: PlayerIndex | null,

--- a/client/src/game/gameState.tsx
+++ b/client/src/game/gameState.tsx
@@ -44,6 +44,7 @@ export function createGameState(): GameState {
 
         will: "",
         notes: "",
+        crossedOutOutlines: [],
         deathNote: "",
         targets: [],
         voted: null,

--- a/client/src/game/messageListener.tsx
+++ b/client/src/game/messageListener.tsx
@@ -262,6 +262,10 @@ export default function messageListener(packet: ToClientPacket){
                 }
             }
         break;
+        case "yourCrossedOutOutlines":
+            if(GAME_MANAGER.state.stateType === "game")
+                GAME_MANAGER.state.crossedOutOutlines = packet.crossedOutOutlines;
+            break;
         case "yourDeathNote":
             if(GAME_MANAGER.state.stateType === "game")
                 GAME_MANAGER.state.deathNote = packet.deathNote ?? "";

--- a/client/src/game/packet.tsx
+++ b/client/src/game/packet.tsx
@@ -98,6 +98,9 @@ export type ToClientPacket = {
     type: "yourNotes",
     notes: string
 } | {
+    type: "yourCrossedOutOutlines",
+    crossedOutOutlines: number[]
+} | {
     type: "yourDeathNote", 
     deathNote: string | null
 } | {
@@ -189,6 +192,9 @@ export type ToServerPacket = {
 } | {
     type: "saveNotes", 
     notes: string
+} | {
+    type: "saveCrossedOutOutlines",
+    crossedOutOutlines: number[]
 } | {
     type: "saveDeathNote", 
     deathNote: string | null

--- a/client/src/menu/game/gameScreenContent/GraveyardMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/GraveyardMenu.tsx
@@ -8,6 +8,7 @@ import { translateRoleOutline } from "../../../game/roleListState.d";
 import StyledText from "../../../components/StyledText";
 import GraveComponent from "../../../components/grave";
 import { Grave } from "../../../game/graveState";
+import { StateListener } from "../../../game/gameManager.d";
 
 type GraveyardMenuProps = {
 }
@@ -18,7 +19,7 @@ type GraveyardMenuState = {
 }
 
 export default class GraveyardMenu extends React.Component<GraveyardMenuProps, GraveyardMenuState> {
-    listener: () => void;
+    listener: StateListener;
     constructor(props: GraveyardMenuProps) {
         super(props);
 
@@ -26,13 +27,19 @@ export default class GraveyardMenu extends React.Component<GraveyardMenuProps, G
             this.state = {
                 gameState : GAME_MANAGER.state,
                 extendedGraveIndex: null,
-                strickenRoleListIndex: []
+                strickenRoleListIndex: GAME_MANAGER.state.crossedOutOutlines
             };
-        this.listener = ()=>{
-            if(GAME_MANAGER.state.stateType === "game")
+        this.listener = (type)=>{
+            if(GAME_MANAGER.state.stateType === "game"){
                 this.setState({
                     gameState: GAME_MANAGER.state
                 });
+                if(type === "yourCrossedOutOutlines"){
+                    this.setState({strickenRoleListIndex: GAME_MANAGER.state.crossedOutOutlines})
+                }
+
+            }
+                
         };  
     }
     componentDidMount() {
@@ -95,6 +102,7 @@ export default class GraveyardMenu extends React.Component<GraveyardMenuProps, G
                         strickenRoleListIndex.push(index);
 
                     this.setState({strickenRoleListIndex:strickenRoleListIndex})
+                    GAME_MANAGER.sendSaveCrossedOutOutlinesPacket(strickenRoleListIndex);
                 }}
                 onMouseDown={(e)=>{
                     // on right click, show a list of all roles that can be in this bucket

--- a/server/src/game/on_client_message.rs
+++ b/server/src/game/on_client_message.rs
@@ -175,6 +175,9 @@ impl Game {
             ToServerPacket::SaveNotes { notes } => {
                 sender_player_ref.set_notes(self, notes);
             },
+            ToServerPacket::SaveCrossedOutOutlines { crossed_out_outlines } => {
+                sender_player_ref.set_crossed_out_outlines(self, crossed_out_outlines);
+            },
             ToServerPacket::SaveDeathNote { death_note } => {
                 sender_player_ref.set_death_note(self, death_note);
             },

--- a/server/src/game/player/mod.rs
+++ b/server/src/game/player/mod.rs
@@ -31,6 +31,7 @@ pub struct Player {
     alive: bool,
     will: String,
     notes: String,
+    crossed_out_outlines: Vec<u8>,
     death_note: Option<String>,
 
     role_labels: HashMap<PlayerReference, Role>,
@@ -84,6 +85,7 @@ impl Player {
             alive: true,
             will: "".to_string(),
             notes: "".to_string(),
+            crossed_out_outlines: vec![],
             death_note: None,
 
             role_labels: HashMap::new(),
@@ -143,6 +145,7 @@ pub mod test {
             alive: true,
             will: "".to_string(),
             notes: "".to_string(),
+            crossed_out_outlines: vec![],
             death_note: None,
 
             role_labels: HashMap::new(),

--- a/server/src/game/player/player_accessors.rs
+++ b/server/src/game/player/player_accessors.rs
@@ -60,6 +60,14 @@ impl PlayerReference{
         self.deref_mut(game).notes = notes;
         self.send_packet(game, ToClientPacket::YourNotes { notes: self.deref(game).notes.clone() })
     }
+
+    pub fn crossed_out_outlines<'a>(&self, game: &'a Game) -> &'a Vec<u8> {
+        &self.deref(game).crossed_out_outlines
+    }
+    pub fn set_crossed_out_outlines(&self, game: &mut Game, crossed_out_outlines: Vec<u8>){
+        self.deref_mut(game).crossed_out_outlines = crossed_out_outlines;
+        self.send_packet(game, ToClientPacket::YourCrossedOutOutlines { crossed_out_outlines: self.deref(game).crossed_out_outlines.clone() });
+    }
     
     pub fn death_note<'a>(&self, game: &'a Game) -> &'a Option<String> {
         &self.deref(game).death_note

--- a/server/src/game/player/player_send_packet.rs
+++ b/server/src/game/player/player_send_packet.rs
@@ -115,6 +115,9 @@ impl PlayerReference{
             ToClientPacket::YourNotes{
                 notes: self.notes(game).clone()
             },
+            ToClientPacket::YourCrossedOutOutlines{
+                crossed_out_outlines: self.crossed_out_outlines(game).clone()
+            },
             ToClientPacket::YourButtons{
                 buttons: AvailableButtons::from_player(game, *self)
             }

--- a/server/src/packet.rs
+++ b/server/src/packet.rs
@@ -97,6 +97,8 @@ pub enum ToClientPacket{
     YourWill{will: String},
     YourNotes{notes: String},
     #[serde(rename_all = "camelCase")]
+    YourCrossedOutOutlines{crossed_out_outlines: Vec<u8>},
+    #[serde(rename_all = "camelCase")]
     YourDeathNote{death_note: Option<String>},
     #[serde(rename_all = "camelCase")]
     YourRoleState{role_state: RoleState},
@@ -194,6 +196,8 @@ pub enum ToServerPacket{
     SendWhisper{player_index: PlayerIndex, text: String},
     SaveWill{will: String},
     SaveNotes{notes: String},
+    #[serde(rename_all = "camelCase")]
+    SaveCrossedOutOutlines{crossed_out_outlines: Vec<u8>},
     #[serde(rename_all = "camelCase")]
     SaveDeathNote{death_note: Option<String>},
 


### PR DESCRIPTION
You can cross out role outlines on the grave menu
Send packet so it can save over refreshes. Slightly tested