### PR TITLE
Better error messages for skip_to

### DIFF
--- a/server/tests/kit/game.rs
+++ b/server/tests/kit/game.rs
@@ -30,32 +30,35 @@ impl TestGame {
     pub fn skip_to(&mut self, phase: PhaseType, day_number: u8) -> &PhaseState {
         // The only briefing phase is Briefing 1
         if phase == PhaseType::Briefing && day_number != 1 {
-            panic!("The only Briefing phase is Briefing 1. Tried to go to Briefing {} from {:?} {}.", day_number, self.current_phase().phase(), self.day_number()); 
+            panic!("The only Briefing phase is Briefing 1. Tried to go to Briefing {day_number} from {:?} {}.", self.current_phase().phase(), self.day_number()); 
         }
-
+    
         // The only phases that occur day 1 are Briefing, Dusk and Night.
         if day_number == 1 && match phase {PhaseType::Briefing | PhaseType::Dusk | PhaseType::Night => false, _ => true} {
-            panic!("There is no {:?} 1. Tried to go to {:?} 1 from {:?} {}. The only phases that occur day 1 are Briefing, Dusk, & Night.", phase, phase, self.current_phase().phase(), self.day_number()); 
+            panic!("There is no {phase:?} 1. Tried to go to {phase:?} 1 from {:?} {}. The only phases that occur day 1 are Briefing, Dusk, & Night.", self.current_phase().phase(), self.day_number()); 
         }
 
         // If the phase & day is in the past
         if self.day_number() > day_number || (self.day_number() == day_number && self.current_phase().phase() > phase) {
-            panic!("Can't skip back in time! Tried to go to {:?} {}, but was already on {:?} {}, skip_to", phase, day_number, self.current_phase().phase(), self.day_number());
+            panic!("Can't skip back in time! Tried to go to {phase:?} {day_number}, but was already on {:?} {}, skip_to", self.current_phase().phase(), self.day_number());
         }
+
+        let origin_phase = self.current_phase().phase();
+        let origin_day = self.day_number();
 
         while self.day_number() != day_number || self.current_phase().phase() != phase {
             if self.day_number() == u8::MAX - 1 && self.current_phase().phase() == PhaseType::Night {
-                panic!("Can't go above the maximum day, skip_to");
+                panic!("Can't go above the maximum day. skip_to called during {origin_phase:?} {origin_day}.");
             }
 
             if self.day_number() > day_number {
-                panic!("Phase {phase:?} {day_number} never occurs in the future!, skip_to");
+                panic!("Phase {phase:?} {day_number} never occurs in the future!. skip_to called during {origin_phase:?} {origin_day}.");
             }
 
             self.next_phase();
 
             if self.day_number() > day_number || (self.day_number() == day_number && self.current_phase().phase() > phase) {
-                panic!("That phase was skipped past. Maybe your test subjects need to vote someone? Tried to go to {:?} {}, but was already on {:?} {}, skip_to", phase, day_number, self.current_phase().phase(), self.day_number());
+                panic!("That phase was skipped past. Maybe your test subjects need to vote someone? Tried to go to {phase:?} {day_number}, but was already on {:?} {}. skip_to called during {origin_phase:?} {origin_day}.", self.current_phase().phase(), self.day_number(),);
             }
         }
 

--- a/server/tests/kit/game.rs
+++ b/server/tests/kit/game.rs
@@ -28,6 +28,16 @@ impl TestGame {
     /// * When the specified day and phase is in the past.
     /// * If this would take the game to a day past the maximum day
     pub fn skip_to(&mut self, phase: PhaseType, day_number: u8) -> &PhaseState {
+        // The only briefing phase is Briefing 1
+        if phase == PhaseType::Briefing && day_number != 1 {
+            panic!("The only Briefing phase is Briefing 1. Tried to go to Briefing {} from {:?} {}.", day_number, self.current_phase().phase(), self.day_number()); 
+        }
+
+        // The only phases that occur day 1 are Briefing, Dusk and Night.
+        if day_number == 1 && match phase {PhaseType::Briefing | PhaseType::Dusk | PhaseType::Night => false, _ => true} {
+            panic!("There is no {:?} 1. Tried to go to {:?} 1 from {:?} {}. The only phases that occur day 1 are Briefing, Dusk, & Night.", phase, phase, self.current_phase().phase(), self.day_number()); 
+        }
+
         // If the phase & day is in the past
         if self.day_number() > day_number || (self.day_number() == day_number && self.current_phase().phase() > phase) {
             panic!("Can't skip back in time! Tried to go to {:?} {}, but was already on {:?} {}, skip_to", phase, day_number, self.current_phase().phase(), self.day_number());


### PR DESCRIPTION
Added more specific error messages and made already extant messages include what phase & day the function was called on.