### PR TITLE
Reworked tally clerk

### DIFF
--- a/client/src/components/ChatMessage.tsx
+++ b/client/src/components/ChatMessage.tsx
@@ -611,7 +611,7 @@ export function translateChatMessage(
         case "gossipResult":
             return translate("chatMessage.gossipResult." + (message.enemies ? "enemies" : "none"));
         case "tallyClerkResult":
-            return translate("chatMessage.tallyClerkResult", message.evilCount);
+            return translate("chatMessage.tallyClerkResult", message.visited, message.visitors);
         case "lookoutResult":
             return translate("chatMessage.lookoutResult", playerListToString(message.players, playerNames));
         case "spyMafiaVisit":
@@ -947,7 +947,8 @@ export type ChatMessageVariant = {
     enemies: boolean
 } | {
     type: "tallyClerkResult",
-    evilCount: number
+    visitors: number,
+    visited: number,
 } | {
     type: "lookoutResult", 
     players: PlayerIndex[]

--- a/client/src/resources/lang/en_us.json
+++ b/client/src/resources/lang/en_us.json
@@ -227,7 +227,8 @@
 
     "role.tallyClerk.name": "Tally Clerk",
     "role.tallyClerk.name:var.0": "Tally Clerks",
-    "role.tallyClerk.target": "Distribute",
+    "controllerId.role.tallyClerk.0.name": "Tally",
+
 
     "role.doctor.name": "Doctor",
     "role.doctor.name:var.0": "Doctors",
@@ -959,7 +960,7 @@
     "chatMessage.snoopResult.inconclusive":"You can't tell what your target is.",
     "chatMessage.gossipResult.none": "Your target didn't visit a player that is enemies with town.",
     "chatMessage.gossipResult.enemies": "Your target visited a player that is enemies with town.",
-    "chatMessage.tallyClerkResult": "\\0 evil players voted guilty at some point today.",
+    "chatMessage.tallyClerkResult": "Your target visited \\0 players, and was visited by \\0 players.",
     "chatMessage.targetsMessage":"Your target got the following message:",
     "chatMessage.youWerePossessed":"You were possessed.",
     "chatMessage.youWerePossessed.immune":"Someone tried to possess you but you are immune.",

--- a/server/src/game/chat/chat_message_variant.rs
+++ b/server/src/game/chat/chat_message_variant.rs
@@ -175,7 +175,7 @@ pub enum ChatMessageVariant {
     SnoopResult{townie: bool},
     GossipResult{enemies: bool},
     #[serde(rename_all = "camelCase")]
-    TallyClerkResult{evil_count: u8},
+    TallyClerkResult{visited: u8, visitors: u8},
 
     EngineerVisitorsRole{role: Role},
     TrapState{state: TrapState},

--- a/server/tests/role.rs
+++ b/server/tests/role.rs
@@ -508,25 +508,22 @@ fn psychic_auras(){
 
 #[test]
 fn tally_clerk_basic(){
-    kit::scenario!(game in Nomination 2 where
-        fg: TallyClerk,
-        townie: Detective,
-        mafioso: Mafioso
+    kit::scenario!(game in Night 1 where
+        clerk: TallyClerk,
+        detect: Detective,
+        snoop: Snoop,
+        _maf: Mafioso
     );
+    clerk.send_ability_input_player_list_typical(detect);
+    detect.send_ability_input_player_list_typical(snoop);
+    snoop.send_ability_input_player_list_typical(detect);
 
-    fg.vote_for_player(Some(townie));
-    mafioso.vote_for_player(Some(townie));
 
-    game.skip_to(Judgement, 2);
-
-    fg.set_verdict(Verdict::Guilty);
-    mafioso.set_verdict(Verdict::Guilty);
-    
-    game.skip_to(Obituary, 3);
+    game.skip_to(Obituary, 2);
     assert_contains!(
-        fg.get_messages_after_night(1),
-        ChatMessageVariant::TallyClerkResult { evil_count: 1 }
-    );
+        clerk.get_messages_after_night(1),
+        ChatMessageVariant::TallyClerkResult { visited: 1, visitors: 2 }
+    );  
 }
 
 


### PR DESCRIPTION
Tally Clerks now choose a player to visit each night.
They learn how many players visited their target (including themself) & how many players their target visited.