### PR TITLE
Unify Transport System

### DIFF
--- a/server/src/game/components/mod.rs
+++ b/server/src/game/components/mod.rs
@@ -21,3 +21,4 @@ pub mod tags;
 pub mod enfranchise;
 pub mod guard;
 pub mod fragile_vest;
+pub mod transporting;

--- a/server/src/game/components/transporting.rs
+++ b/server/src/game/components/transporting.rs
@@ -1,0 +1,58 @@
+
+use crate::game::{
+    Game,
+    chat::ChatMessageVariant,
+    event::on_midnight::MidnightVariables,
+    player::PlayerReference,
+    role::Role,
+    visit::Visit,
+};
+use crate::vec_map::VecMap;
+
+
+#[derive(PartialOrd, Ord, PartialEq, Eq)]
+pub enum TransportPriority {
+    Transporting = 0,
+    Warping = 1,
+    Bodyguard = 2,
+    None = 3
+}
+
+
+pub fn transport_priority(me: &PlayerReference, game: &mut Game) -> TransportPriority {
+    match me.role(game) {
+        Role::Transporter => TransportPriority::Transporting,
+        Role::Warper | Role::Porter => TransportPriority::Warping,
+        Role::Bodyguard => TransportPriority::Bodyguard,
+        _ => TransportPriority::None
+    }
+}
+
+
+pub fn transport(
+    me: &PlayerReference, game: &mut Game, midnight_variables: &mut MidnightVariables,
+    player_map: &VecMap<PlayerReference, PlayerReference>, send_message: bool, filter: &dyn Fn(&Visit) -> bool
+) -> Vec<Visit> {
+    if send_message {
+        for p in player_map.keys() {
+            p.push_night_message(midnight_variables, ChatMessageVariant::Transported);
+        }
+    }
+    
+    let self_transport_priority = transport_priority(me, game);
+    let mut res = vec![];
+    
+    for player_ref in PlayerReference::all_players(game) {
+        if transport_priority(&player_ref, game) <= self_transport_priority {continue;}
+
+        let new_visits = player_ref.all_night_visits_cloned(game).clone().into_iter().map(|mut v| {
+            let Some(new_target) = player_map.get(&v.target).filter(|_| filter(&v)) else {return v};
+            v.target = *new_target;
+            res.push(v);
+            v
+        }).collect();
+        player_ref.set_night_visits(game, new_visits);
+    }
+
+    res
+}

--- a/server/src/game/role/bodyguard.rs
+++ b/server/src/game/role/bodyguard.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 
 use crate::game::attack_power::AttackPower;
 use crate::game::attack_power::DefensePower;
+use crate::game::components::transporting::transport;
 use crate::game::event::on_midnight::{MidnightVariables, OnMidnightPriority};
 use crate::game::grave::GraveKiller;
 use crate::game::phase::PhaseType;
@@ -11,6 +12,9 @@ use crate::game::player::PlayerReference;
 use crate::game::visit::Visit;
 
 use crate::game::Game;
+
+use crate::vec_map::VecMap;
+
 use super::{
     ControllerID, ControllerParametersMap,
     GetClientRoleState, Role,
@@ -51,22 +55,14 @@ impl RoleStateImpl for Bodyguard {
         match priority {
             OnMidnightPriority::Bodyguard => {
                 let actor_visits = actor_ref.untagged_night_visits_cloned(game);
-                let Some(visit) = actor_visits.first() else {return};
-                let target_ref = visit.target;
+                let Some(target_ref) = actor_visits.get(0).map(|v| v.target) else {return};
+                
                 if actor_ref == target_ref {return}
-
-                let mut redirected_player_refs = vec![];
-                for attacker_ref in PlayerReference::all_players(game){
-                    let mut new_visits = vec![];
-                    for mut attacking_visit in attacker_ref.all_night_visits_cloned(game).clone(){
-                        if attacking_visit.target == target_ref && attacking_visit.attack {
-                            attacking_visit.target = actor_ref;
-                            redirected_player_refs.push(attacker_ref);
-                        }
-                        new_visits.push(attacking_visit);
-                    }
-                    attacker_ref.set_night_visits(game, new_visits);
-                }
+                
+                let redirected_player_refs = transport(
+                    &actor_ref, game, midnight_variables,
+                    &VecMap::new_from_vec(vec![(target_ref, actor_ref)]), false, &|v| v.attack
+                ).iter().map(|v| v.visitor).collect();
 
                 actor_ref.set_role_state(game, Bodyguard {
                     self_shields_remaining: self.self_shields_remaining, 

--- a/server/src/game/role/warper.rs
+++ b/server/src/game/role/warper.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 
 use crate::game::ability_input::AvailableTwoPlayerOptionSelection;
+use crate::game::components::transporting::transport;
 use crate::game::event::on_midnight::{MidnightVariables, OnMidnightPriority};
 use crate::game::grave::Grave;
 use crate::game::phase::PhaseType;
@@ -9,6 +10,8 @@ use crate::game::{attack_power::DefensePower, chat::ChatMessageVariant};
 use crate::game::player::PlayerReference;
 use crate::game::visit::Visit;
 use crate::game::Game;
+
+use crate::vec_map::VecMap;
 
 use super::{common_role, ControllerID, ControllerParametersMap, Role, RoleStateImpl};
 
@@ -23,28 +26,18 @@ impl RoleStateImpl for Warper {
     fn on_midnight(self, game: &mut Game, midnight_variables: &mut MidnightVariables, actor_ref: PlayerReference, priority: OnMidnightPriority) {
         if priority != OnMidnightPriority::Warper {return;}
     
-        let transporter_visits = actor_ref.untagged_night_visits_cloned(game).clone();
-        let Some(first_visit) = transporter_visits.get(0) else {return};
-        let Some(second_visit) = transporter_visits.get(1) else {return};
+        let transporter_visits = actor_ref.untagged_night_visits_cloned(game);
+        let Some(first_visit) = transporter_visits.get(0).map(|v| v.target) else {return};
+        let Some(second_visit) = transporter_visits.get(1).map(|v| v.target) else {return};
         
+        transport(
+            &actor_ref, game, midnight_variables,
+            &VecMap::new_from_vec(vec![(first_visit, second_visit)]), true, &|_| true
+        );
         
-        first_visit.target.push_night_message(midnight_variables, ChatMessageVariant::Transported);
-        actor_ref.push_night_message(midnight_variables, ChatMessageVariant::TargetHasRole { role: first_visit.target.role(game) });
-    
-        for player_ref in PlayerReference::all_players(game){
-            if player_ref == actor_ref {continue;}
-            if player_ref.role(game) == Role::Porter {continue;}
-            if player_ref.role(game) == Role::Warper {continue;}
-            if player_ref.role(game) == Role::Transporter {continue;}
-
-            let new_visits = player_ref.all_night_visits_cloned(game).clone().into_iter().map(|mut v|{
-                if v.target == first_visit.target {
-                    v.target = second_visit.target;
-                }
-                v
-            }).collect();
-            player_ref.set_night_visits(game, new_visits);
-        }
+        actor_ref.push_night_message(
+            midnight_variables, ChatMessageVariant::TargetHasRole { role: first_visit.role(game) }
+        );
     }
     fn on_phase_start(self, game: &mut Game, actor_ref: PlayerReference, _phase: PhaseType){
         if

--- a/server/tests/transporting.rs
+++ b/server/tests/transporting.rs
@@ -1,0 +1,15 @@
+use mafia_server::game::components::transporting::TransportPriority;
+
+#[test]
+fn test_transport_ord() {
+    assert!(TransportPriority::Transporting <= TransportPriority::Transporting);
+    assert!(TransportPriority::Transporting <= TransportPriority::Warping);
+    assert!(TransportPriority::Transporting <= TransportPriority::Bodyguard);
+    assert!(TransportPriority::Transporting <= TransportPriority::None);
+    assert!(TransportPriority::Warping <= TransportPriority::Warping);
+    assert!(TransportPriority::Warping <= TransportPriority::Bodyguard);
+    assert!(TransportPriority::Warping <= TransportPriority::None);
+    assert!(TransportPriority::Bodyguard <= TransportPriority::Bodyguard);
+    assert!(TransportPriority::Bodyguard <= TransportPriority::None);
+    assert!(TransportPriority::None <= TransportPriority::None);
+}


### PR DESCRIPTION
Unify the transport system to use shared logic, instead of being implemented separately between different roles.

There is a small mechanical difference with bodyguard.  It will now not transport visits by transporters, warpers, or porters, none of which should be attacking so it shouldn't make a difference anyways, and I believe will be smoothed out in future changes to how abilities work, should it be an issue.