### PR TITLE
Advanced Filtering for the Wiki Page

### DIFF
--- a/.github/workflows/checks-client.yml
+++ b/.github/workflows/checks-client.yml
@@ -26,9 +26,9 @@ jobs:
         working-directory: ./client
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 26.x
       - name: Enable pnpm

--- a/.github/workflows/checks-client.yml
+++ b/.github/workflows/checks-client.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 26.x
       - name: Enable pnpm
         run: corepack enable
       - name: Install dependencies

--- a/.github/workflows/checks-client.yml
+++ b/.github/workflows/checks-client.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Enable pnpm
         run: corepack enable
       - name: Install dependencies

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.9.0",
+  "packageManager": "pnpm@11.5.0",
   "type": "module",
   "dependencies": {
     "@types/dompurify": "^3.0.2",

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: false

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - '.'
+
 allowBuilds:
   esbuild: false

--- a/client/src/components/CheckBox.tsx
+++ b/client/src/components/CheckBox.tsx
@@ -6,6 +6,7 @@ export default function CheckBox(props: {
     checked: boolean,
     onChange: (checked: boolean) => void
 }) {
+    // TODO: Change to button
     return <label
         className="checkbox"
         onClick={()=>{

--- a/client/src/components/Popover.tsx
+++ b/client/src/components/Popover.tsx
@@ -150,5 +150,5 @@ export default function Popover<T extends HTMLElement = HTMLElement>(props: Read
         }
     }, [props]);
 
-    return <div ref={thisRef} />
+    return <div ref={thisRef} hidden={true}/>
 }

--- a/client/src/components/Wiki.tsx
+++ b/client/src/components/Wiki.tsx
@@ -177,7 +177,7 @@ function WikiSearchResults(props: Readonly<{
         if (inLobbyOrGame) {
             return "default";
         } else if (gameModes.some(mode => mode.name === "Experimental")) {
-            return ["Experimental", getGameModeEnabledPagesFilter(gameModes, "Experimental")];
+            return ["gamemode:Experimental", getGameModeEnabledPagesFilter(gameModes, "Experimental")];
         } else {
             return ["all", () => true];
         }
@@ -274,7 +274,7 @@ function WikiDisabledSelector(props: Readonly<{
 
         for (const gameMode of gameModes) {
             options.set(
-                gameMode.name,
+                "gamemode:" + gameMode.name,
                 [
                     <StyledText key={gameMode.name} noLinks={true}>
                         {gameMode.name}
@@ -298,7 +298,8 @@ function WikiDisabledSelector(props: Readonly<{
                 if (value === "all") {
                     updateWikiDisabledFilter(["all", () => true]);
                 } else {
-                    updateWikiDisabledFilter([value, getGameModeEnabledPagesFilter(gameModes, value)]);
+                    const gameModeName = value.replace("gamemode:", "");
+                    updateWikiDisabledFilter([value, getGameModeEnabledPagesFilter(gameModes, gameModeName)]);
                 }
             }} />
         </label>}

--- a/client/src/components/Wiki.tsx
+++ b/client/src/components/Wiki.tsx
@@ -19,6 +19,7 @@ import Select from "./Select";
 import { loadGameModesParsed } from "../game/localStorage";
 import { isFailure } from "./gameModeSettings/gameMode/parse";
 import { GameModeContext } from "./gameModeSettings/GameModesEditor";
+import { GameMode } from "./gameModeSettings/gameMode";
 
 
 export function setWikiSearchPage(page: WikiArticleLink, anchorController: AnchorController, menuController?: MenuController) {
@@ -159,10 +160,28 @@ function WikiSearchResults(props: Readonly<{
         ["modifierSettings"],
         MODIFIERS as any as ModifierID[]
     )!;
+    const inLobbyOrGame = useLobbyOrGameState(() => true, [], false)!;
 
-    const [hideDisabled, setHideDisabled] = useState(false);
+    const gameModes = useMemo(() => {
+        const gameModes = loadGameModesParsed();
+        if (isFailure(gameModes)) {
+            return [];
+        } else {
+            return gameModes.value.gameModes;
+        }
+    }, []);
+
+    const [hideDisabled, setHideDisabled] = useState(true);
     // Default means to hide pages that are disabled by the current game settings
-    const [wikiDisabledFilter, setWikiDisabledFilter] = useState<WikiDisabledFilter | "default">("default");
+    const [wikiDisabledFilter, setWikiDisabledFilter] = useState<[string, WikiDisabledFilter] | "default">(() => {
+        if (inLobbyOrGame) {
+            return "default";
+        } else if (gameModes.some(mode => mode.name === "Experimental")) {
+            return ["Experimental", getGameModeEnabledPagesFilter(gameModes, "Experimental")];
+        } else {
+            return ["all", () => true];
+        }
+    });
 
     const getSearchResults = useCallback((search: string) => {
         const out = [
@@ -177,7 +196,12 @@ function WikiSearchResults(props: Readonly<{
     [props.searchQuery, getSearchResults])
 
     return <div className="wiki-results" tabIndex={-1}>
-        <WikiDisabledSelector hideDisabled={hideDisabled} setWikiDisabledFilter={setWikiDisabledFilter} setHideDisabled={setHideDisabled} />
+        <WikiDisabledSelector
+            hideDisabled={hideDisabled}
+            setHideDisabled={setHideDisabled}
+            wikiDisabledFilter={wikiDisabledFilter}
+            setWikiDisabledFilter={setWikiDisabledFilter}
+        />
         {props.searchQuery === ""
             ? <WikiMainPage 
                 enabledRoles={enabledRoles} 
@@ -198,12 +222,35 @@ function WikiSearchResults(props: Readonly<{
     </div>
 }
 
+function getGameModeEnabledPagesFilter(gameModes: GameMode[], gameModeName: string): WikiDisabledFilter {
+    return function (page: WikiArticleLink) {
+        const gameMode = gameModes.find(mode => mode.name === gameModeName);
+        if (!gameMode) {
+            return true;
+        }
+        const enabledRoles: Role[] = [];
+        const enabledModifiers: ModifierID[] = [];
+        for (const [_number, data] of Object.entries(gameMode.data)) {
+            for (const role of data.enabledRoles) {
+                enabledRoles.push(role);
+            }
+            for (const [key, value] of data.modifierSettings) {
+                if (value) {
+                    enabledModifiers.push(key);
+                }
+            }
+        }
+        return wikiPageIsEnabled(page, enabledRoles, enabledModifiers, "default")
+    }
+}
+
 export type WikiDisabledFilter = (page: WikiArticleLink) => boolean;
 
 function WikiDisabledSelector(props: Readonly<{
     hideDisabled: boolean,
-    setWikiDisabledFilter: (filter: WikiDisabledFilter | "default") => void
     setHideDisabled: (hide: boolean) => void
+    wikiDisabledFilter: [string, WikiDisabledFilter] | "default",
+    setWikiDisabledFilter: React.Dispatch<React.SetStateAction<[string, WikiDisabledFilter] | "default">>
 }>): ReactElement {
     const inLobbyOrGame = useLobbyOrGameState(() => true, [], false)!;
 
@@ -216,14 +263,14 @@ function WikiDisabledSelector(props: Readonly<{
         }
     }, []);
 
+    const updateWikiDisabledFilter = useCallback((filter: [string, WikiDisabledFilter] | "default") => {
+        props.setWikiDisabledFilter(() => filter);
+    }, [props]);
+
     const optionsSearch = useMemo(() => {
         const options = new Map<string, [React.ReactNode, string]>();
 
         options.set("all", [translate("wiki.disabledSelector.all"), "all"]);
-
-        if (inLobbyOrGame) {
-            options.set("default", [translate("wiki.disabledSelector.enabled"), "enabled"]);
-        }
 
         for (const gameMode of gameModes) {
             options.set(
@@ -238,50 +285,31 @@ function WikiDisabledSelector(props: Readonly<{
         }
 
         return options;
-    }, []);
+    }, [gameModes, inLobbyOrGame]);
 
-    
-    const defaultValue = useMemo(() => {
-        if (gameModes.some(mode => mode.name === "Experimental")) {
-            return "Experimental";
-        }
-        return inLobbyOrGame ? "default" : "all";
-    }, [inLobbyOrGame, gameModes])
+    const selectedValue = useMemo(() => {
+        return typeof props.wikiDisabledFilter === "string" ? props.wikiDisabledFilter : props.wikiDisabledFilter[0]
+    }, [props.wikiDisabledFilter])
 
-    return <label className="centered-label">
-        {translate("hideDisabled")}
-        <CheckBox 
-            checked={props.hideDisabled} 
-            onChange={checked => props.setHideDisabled(checked)}
-        />
-        <Select value={defaultValue} optionsSearch={optionsSearch} onChange={(value) => {
-            if (value === "all") {
-                props.setWikiDisabledFilter(() => true);
-            } else if (value === "default") {
-                props.setWikiDisabledFilter("default");
-            } else {
-                props.setWikiDisabledFilter((page) => {
-                    const gameMode = gameModes.find(mode => mode.name === value);
-                    if (!gameMode) {
-                        return true;
-                    }
-                    const enabledRoles: Role[] = [];
-                    const enabledModifiers: ModifierID[] = [];
-                    for (const [_number, data] of Object.entries(gameMode.data)) {
-                        for (const role of data.enabledRoles) {
-                            enabledRoles.push(role);
-                        }
-                        for (const [key, value] of Object.entries(data.modifierSettings)) {
-                            if (value) {
-                                enabledModifiers.push(key as ModifierID);
-                            }
-                        }
-                    }
-                    return wikiPageIsEnabled(page, enabledRoles, enabledModifiers, "default")
-                });
-            }
-        }} />
-    </label>
+    return <div className="wiki-disabled-selector">
+        {!inLobbyOrGame && <label className="centered-label">
+            {translate("wiki.disabledSelector.gameMode")}
+            <Select value={selectedValue} optionsSearch={optionsSearch} onChange={(value) => {
+                if (value === "all") {
+                    updateWikiDisabledFilter(["all", () => true]);
+                } else {
+                    updateWikiDisabledFilter([value, getGameModeEnabledPagesFilter(gameModes, value)]);
+                }
+            }} />
+        </label>}
+        {selectedValue !== "all" && <label className="centered-label">
+            {translate("hideDisabled")}
+            <CheckBox 
+                checked={props.hideDisabled} 
+                onChange={checked => props.setHideDisabled(checked)}
+            />
+        </label>}
+    </div>
 }
 
 function WikiMainPage(props: Readonly<{
@@ -289,7 +317,7 @@ function WikiMainPage(props: Readonly<{
     enabledRoles: Role[],
     enabledModifiers: ModifierID[],
     hideDisabled: boolean,
-    wikiDisabledFilter: WikiDisabledFilter | "default",
+    wikiDisabledFilter: [string, WikiDisabledFilter] | "default",
     onChooseArticle: (article: WikiArticleLink) => void
 }>): ReactElement {
     const articlePartitions = useMemo(() => 
@@ -329,6 +357,7 @@ function WikiMainPage(props: Readonly<{
                                 .filter(page => !props.hideDisabled || wikiPageIsEnabled(page, props.enabledRoles, props.enabledModifiers, props.wikiDisabledFilter))}
                             enabledRoles={props.enabledRoles}
                             enabledModifiers={props.enabledModifiers}
+                            wikiDisabledFilter={props.wikiDisabledFilter}
                         />
                     </div>
                 })}
@@ -339,6 +368,7 @@ function WikiMainPage(props: Readonly<{
                 .filter(page => !props.hideDisabled || wikiPageIsEnabled(page, props.enabledRoles, props.enabledModifiers, props.wikiDisabledFilter))}
             enabledRoles={props.enabledRoles}
             enabledModifiers={props.enabledModifiers}
+            wikiDisabledFilter={props.wikiDisabledFilter}
         />
     </div>
 }
@@ -474,7 +504,7 @@ function WikiSearchResult(props: Readonly<{
     onChooseArticle: (article: WikiArticleLink) => void
 }>): ReactElement {
     return <button key={props.page} onClick={() => props.onChooseArticle(props.page)}>
-        <StyledText noLinks={true} className={props.className}>
+        <StyledText noLinks={true}  className={props.className}>
             {getArticleTitle(props.page)}
         </StyledText>
 </button>

--- a/client/src/components/Wiki.tsx
+++ b/client/src/components/Wiki.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import translate from "../game/lang";
 import "./wiki.css";
 import { Role, getMainRoleSetFromRole } from "../game/roleState.d";
@@ -15,6 +15,10 @@ import { useLobbyOrGameState } from "./useHooks";
 import { MODIFIERS, ModifierID } from "../game/modifiers";
 import Masonry from "react-responsive-masonry";
 import CheckBox from "./CheckBox";
+import Select from "./Select";
+import { loadGameModesParsed } from "../game/localStorage";
+import { isFailure } from "./gameModeSettings/gameMode/parse";
+import { GameModeContext } from "./gameModeSettings/GameModesEditor";
 
 
 export function setWikiSearchPage(page: WikiArticleLink, anchorController: AnchorController, menuController?: MenuController) {
@@ -156,7 +160,9 @@ function WikiSearchResults(props: Readonly<{
         MODIFIERS as any as ModifierID[]
     )!;
 
-    const [hideDisabled, setHideDisabled] = useState(true);
+    const [hideDisabled, setHideDisabled] = useState(false);
+    // Default means to hide pages that are disabled by the current game settings
+    const [wikiDisabledFilter, setWikiDisabledFilter] = useState<WikiDisabledFilter | "default">("default");
 
     const getSearchResults = useCallback((search: string) => {
         const out = [
@@ -171,30 +177,111 @@ function WikiSearchResults(props: Readonly<{
     [props.searchQuery, getSearchResults])
 
     return <div className="wiki-results" tabIndex={-1}>
-        {!props.static && <label className="centered-label">
-            {translate("hideDisabled")}
-            <CheckBox 
-                checked={hideDisabled} 
-                onChange={checked => setHideDisabled(checked)}
-            />
-        </label>}
+        <WikiDisabledSelector hideDisabled={hideDisabled} setWikiDisabledFilter={setWikiDisabledFilter} setHideDisabled={setHideDisabled} />
         {props.searchQuery === ""
             ? <WikiMainPage 
                 enabledRoles={enabledRoles} 
                 enabledModifiers={enabledModifiers} 
                 hideDisabled={hideDisabled}
+                wikiDisabledFilter={wikiDisabledFilter}
                 articles={results} 
                 onChooseArticle={props.onChooseArticle}
             /> : <div>
                 {results
-                    .filter(page => wikiPageIsEnabled(page, enabledRoles, enabledModifiers) || !hideDisabled)
+                    .filter(page => !hideDisabled || wikiPageIsEnabled(page, enabledRoles, enabledModifiers, wikiDisabledFilter))
                     .map(page => <WikiSearchResult key={page} 
                         page={page} 
-                        className={wikiPageIsEnabled(page, enabledRoles, enabledModifiers) ? "" : "keyword-disabled"} 
+                        className={wikiPageIsEnabled(page, enabledRoles, enabledModifiers, wikiDisabledFilter) ? "" : "keyword-disabled"} 
                         onChooseArticle={() => props.onChooseArticle(page)}
                     />)}
             </div>}
     </div>
+}
+
+export type WikiDisabledFilter = (page: WikiArticleLink) => boolean;
+
+function WikiDisabledSelector(props: Readonly<{
+    hideDisabled: boolean,
+    setWikiDisabledFilter: (filter: WikiDisabledFilter | "default") => void
+    setHideDisabled: (hide: boolean) => void
+}>): ReactElement {
+    const inLobbyOrGame = useLobbyOrGameState(() => true, [], false)!;
+
+    const gameModes = useMemo(() => {
+        const gameModes = loadGameModesParsed();
+        if (isFailure(gameModes)) {
+            return [];
+        } else {
+            return gameModes.value.gameModes;
+        }
+    }, []);
+
+    const optionsSearch = useMemo(() => {
+        const options = new Map<string, [React.ReactNode, string]>();
+
+        options.set("all", [translate("wiki.disabledSelector.all"), "all"]);
+
+        if (inLobbyOrGame) {
+            options.set("default", [translate("wiki.disabledSelector.enabled"), "enabled"]);
+        }
+
+        for (const gameMode of gameModes) {
+            options.set(
+                gameMode.name,
+                [
+                    <StyledText key={gameMode.name} noLinks={true}>
+                        {gameMode.name}
+                    </StyledText>,
+                    gameMode.name
+                ]
+            );
+        }
+
+        return options;
+    }, []);
+
+    
+    const defaultValue = useMemo(() => {
+        if (gameModes.some(mode => mode.name === "Experimental")) {
+            return "Experimental";
+        }
+        return inLobbyOrGame ? "default" : "all";
+    }, [inLobbyOrGame, gameModes])
+
+    return <label className="centered-label">
+        {translate("hideDisabled")}
+        <CheckBox 
+            checked={props.hideDisabled} 
+            onChange={checked => props.setHideDisabled(checked)}
+        />
+        <Select value={defaultValue} optionsSearch={optionsSearch} onChange={(value) => {
+            if (value === "all") {
+                props.setWikiDisabledFilter(() => true);
+            } else if (value === "default") {
+                props.setWikiDisabledFilter("default");
+            } else {
+                props.setWikiDisabledFilter((page) => {
+                    const gameMode = gameModes.find(mode => mode.name === value);
+                    if (!gameMode) {
+                        return true;
+                    }
+                    const enabledRoles: Role[] = [];
+                    const enabledModifiers: ModifierID[] = [];
+                    for (const [_number, data] of Object.entries(gameMode.data)) {
+                        for (const role of data.enabledRoles) {
+                            enabledRoles.push(role);
+                        }
+                        for (const [key, value] of Object.entries(data.modifierSettings)) {
+                            if (value) {
+                                enabledModifiers.push(key as ModifierID);
+                            }
+                        }
+                    }
+                    return wikiPageIsEnabled(page, enabledRoles, enabledModifiers, "default")
+                });
+            }
+        }} />
+    </label>
 }
 
 function WikiMainPage(props: Readonly<{
@@ -202,6 +289,7 @@ function WikiMainPage(props: Readonly<{
     enabledRoles: Role[],
     enabledModifiers: ModifierID[],
     hideDisabled: boolean,
+    wikiDisabledFilter: WikiDisabledFilter | "default",
     onChooseArticle: (article: WikiArticleLink) => void
 }>): ReactElement {
     const articlePartitions = useMemo(() => 
@@ -238,7 +326,7 @@ function WikiMainPage(props: Readonly<{
                         <PageCollection 
                             title={translate(`wiki.category.${category}`)}
                             pages={pages
-                                .filter(page => wikiPageIsEnabled(page, props.enabledRoles, props.enabledModifiers) || !props.hideDisabled)}
+                                .filter(page => !props.hideDisabled || wikiPageIsEnabled(page, props.enabledRoles, props.enabledModifiers, props.wikiDisabledFilter))}
                             enabledRoles={props.enabledRoles}
                             enabledModifiers={props.enabledModifiers}
                         />
@@ -248,7 +336,7 @@ function WikiMainPage(props: Readonly<{
         <PageCollection 
             title={translate(`wiki.category.uncategorized`)}
             pages={articlePartitions["uncategorized"]
-                .filter(page => wikiPageIsEnabled(page, props.enabledRoles, props.enabledModifiers) || !props.hideDisabled)}
+                .filter(page => !props.hideDisabled || wikiPageIsEnabled(page, props.enabledRoles, props.enabledModifiers, props.wikiDisabledFilter))}
             enabledRoles={props.enabledRoles}
             enabledModifiers={props.enabledModifiers}
         />

--- a/client/src/components/Wiki.tsx
+++ b/client/src/components/Wiki.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import React, { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import translate from "../game/lang";
 import "./wiki.css";
 import { Role, getMainRoleSetFromRole } from "../game/roleState.d";
@@ -18,7 +18,6 @@ import CheckBox from "./CheckBox";
 import Select from "./Select";
 import { loadGameModesParsed } from "../game/localStorage";
 import { isFailure } from "./gameModeSettings/gameMode/parse";
-import { GameModeContext } from "./gameModeSettings/GameModesEditor";
 import { GameMode } from "./gameModeSettings/gameMode";
 
 
@@ -223,25 +222,21 @@ function WikiSearchResults(props: Readonly<{
 }
 
 function getGameModeEnabledPagesFilter(gameModes: GameMode[], gameModeName: string): WikiDisabledFilter {
-    return function (page: WikiArticleLink) {
-        const gameMode = gameModes.find(mode => mode.name === gameModeName);
-        if (!gameMode) {
-            return true;
-        }
-        const enabledRoles: Role[] = [];
-        const enabledModifiers: ModifierID[] = [];
-        for (const [_number, data] of Object.entries(gameMode.data)) {
-            for (const role of data.enabledRoles) {
-                enabledRoles.push(role);
-            }
-            for (const [key, value] of data.modifierSettings) {
-                if (value) {
-                    enabledModifiers.push(key);
-                }
-            }
-        }
-        return wikiPageIsEnabled(page, enabledRoles, enabledModifiers, "default")
+    const gameMode = gameModes.find(mode => mode.name === gameModeName);
+    if (!gameMode) {
+        return () => true;
     }
+
+    const enabledRoles: Role[] = [];
+    const enabledModifiers: ModifierID[] = [];
+
+    for (const data of Object.values(gameMode.data)) {
+        enabledRoles.push(...data.enabledRoles);
+        for (const [key,] of data.modifierSettings) {
+            enabledModifiers.push(key);
+        }
+    }
+    return (page: WikiArticleLink) => wikiPageIsEnabled(page, enabledRoles, enabledModifiers, "default")
 }
 
 export type WikiDisabledFilter = (page: WikiArticleLink) => boolean;

--- a/client/src/components/Wiki.tsx
+++ b/client/src/components/Wiki.tsx
@@ -90,6 +90,28 @@ export default function Wiki(props: Readonly<{
         setHistory([]);
         setArticle(null);
     }
+    const inLobbyOrGame = useLobbyOrGameState(() => true, [], false)!;
+
+    const gameModes = useMemo(() => {
+        const gameModes = loadGameModesParsed();
+        if (isFailure(gameModes)) {
+            return [];
+        } else {
+            return gameModes.value.gameModes;
+        }
+    }, []);
+
+    const [hideDisabled, setHideDisabled] = useState(true);
+    // Default means to hide pages that are disabled by the current game settings
+    const [wikiDisabledFilter, setWikiDisabledFilter] = useState<[string, WikiDisabledFilter] | "default">(() => {
+        if (inLobbyOrGame) {
+            return "default";
+        } else if (gameModes.some(mode => mode.name === "Experimental")) {
+            return ["gamemode:Experimental", getGameModeEnabledPagesFilter(gameModes, "Experimental")];
+        } else {
+            return ["all", () => true];
+        }
+    });
 
     return <div className="wiki-search">
         <WikiSearchBar 
@@ -107,10 +129,18 @@ export default function Wiki(props: Readonly<{
                 enabledModifiers={props.enabledModifiers}
                 onChooseArticle={chooseArticle}
                 static={props.static === true}
+                hideDisabled={hideDisabled}
+                wikiDisabledFilter={wikiDisabledFilter}
             />
             :
             <WikiArticle article={article}/>
         }
+        <WikiDisabledSelector
+            hideDisabled={hideDisabled}
+            setHideDisabled={setHideDisabled}
+            wikiDisabledFilter={wikiDisabledFilter}
+            setWikiDisabledFilter={setWikiDisabledFilter}
+        />
     </div>
 }
 
@@ -147,7 +177,9 @@ function WikiSearchResults(props: Readonly<{
     enabledRoles: Role[],
     enabledModifiers: ModifierID[],
     onChooseArticle: (article: WikiArticleLink) => void,
-    static: boolean
+    static: boolean,
+    hideDisabled: boolean,
+    wikiDisabledFilter: [string, WikiDisabledFilter] | "default",
 }>): ReactElement {
     const enabledRoles = useLobbyOrGameState(
         gameState => gameState.enabledRoles,
@@ -159,28 +191,6 @@ function WikiSearchResults(props: Readonly<{
         ["modifierSettings"],
         MODIFIERS as any as ModifierID[]
     )!;
-    const inLobbyOrGame = useLobbyOrGameState(() => true, [], false)!;
-
-    const gameModes = useMemo(() => {
-        const gameModes = loadGameModesParsed();
-        if (isFailure(gameModes)) {
-            return [];
-        } else {
-            return gameModes.value.gameModes;
-        }
-    }, []);
-
-    const [hideDisabled, setHideDisabled] = useState(true);
-    // Default means to hide pages that are disabled by the current game settings
-    const [wikiDisabledFilter, setWikiDisabledFilter] = useState<[string, WikiDisabledFilter] | "default">(() => {
-        if (inLobbyOrGame) {
-            return "default";
-        } else if (gameModes.some(mode => mode.name === "Experimental")) {
-            return ["gamemode:Experimental", getGameModeEnabledPagesFilter(gameModes, "Experimental")];
-        } else {
-            return ["all", () => true];
-        }
-    });
 
     const getSearchResults = useCallback((search: string) => {
         const out = [
@@ -195,26 +205,20 @@ function WikiSearchResults(props: Readonly<{
     [props.searchQuery, getSearchResults])
 
     return <div className="wiki-results" tabIndex={-1}>
-        <WikiDisabledSelector
-            hideDisabled={hideDisabled}
-            setHideDisabled={setHideDisabled}
-            wikiDisabledFilter={wikiDisabledFilter}
-            setWikiDisabledFilter={setWikiDisabledFilter}
-        />
         {props.searchQuery === ""
             ? <WikiMainPage 
                 enabledRoles={enabledRoles} 
                 enabledModifiers={enabledModifiers} 
-                hideDisabled={hideDisabled}
-                wikiDisabledFilter={wikiDisabledFilter}
+                hideDisabled={props.hideDisabled}
+                wikiDisabledFilter={props.wikiDisabledFilter}
                 articles={results} 
                 onChooseArticle={props.onChooseArticle}
             /> : <div>
                 {results
-                    .filter(page => !hideDisabled || wikiPageIsEnabled(page, enabledRoles, enabledModifiers, wikiDisabledFilter))
+                    .filter(page => !props.hideDisabled || wikiPageIsEnabled(page, enabledRoles, enabledModifiers, props.wikiDisabledFilter))
                     .map(page => <WikiSearchResult key={page} 
                         page={page} 
-                        className={wikiPageIsEnabled(page, enabledRoles, enabledModifiers, wikiDisabledFilter) ? "" : "keyword-disabled"} 
+                        className={wikiPageIsEnabled(page, enabledRoles, enabledModifiers, props.wikiDisabledFilter) ? "" : "keyword-disabled"} 
                         onChooseArticle={() => props.onChooseArticle(page)}
                     />)}
             </div>}

--- a/client/src/components/WikiArticle.tsx
+++ b/client/src/components/WikiArticle.tsx
@@ -11,7 +11,7 @@ import "./wiki.css";
 import GAME_MANAGER, { replaceMentions } from "..";
 import { useLobbyOrGameState } from "./useHooks";
 import DetailsSummary from "./DetailsSummary";
-import { partitionWikiPages, WikiCategory } from "./Wiki";
+import { partitionWikiPages, WikiCategory, WikiDisabledFilter } from "./Wiki";
 import { MODIFIERS, ModifierID } from "../game/modifiers";
 import DUMMY_ROLE_LIST from "../resources/dummyRoleList.json";
 import Masonry from "react-responsive-masonry";
@@ -175,7 +175,8 @@ export function PageCollection(props: Readonly<{
     pages: WikiArticleLink[],
     enabledRoles: Role[],
     enabledModifiers: ModifierID[],
-    children?: ReactNode
+    children?: ReactNode,
+    wikiDisabledFilter?: [string, WikiDisabledFilter] | "default"
 }>): ReactElement | null {
     if (props.pages.length === 0) {
         return null;
@@ -187,7 +188,7 @@ export function PageCollection(props: Readonly<{
         </h3>
         {props.children}
         {props.pages.map((page) => {
-            return <button key={page} className={wikiPageIsEnabled(page, props.enabledRoles, props.enabledModifiers) ? "" : "keyword-disabled"} 
+            return <button key={page} className={wikiPageIsEnabled(page, props.enabledRoles, props.enabledModifiers, props.wikiDisabledFilter) ? "" : "keyword-disabled"} 
                 onClick={() => GAME_MANAGER.setWikiArticle(page)}
             >
                 <StyledText noLinks={true}>{getArticleTitle(page)}</StyledText>

--- a/client/src/components/WikiArticleLink.tsx
+++ b/client/src/components/WikiArticleLink.tsx
@@ -57,10 +57,10 @@ export function wikiPageIsEnabled(
     page: WikiArticleLink,
     enabledRoles: Role[],
     enabledModifiers: ModifierID[],
-    wikiDisabledFilter: WikiDisabledFilter | "default" = "default"
+    wikiDisabledFilter: [string, WikiDisabledFilter] | "default" = "default"
 ): boolean {
     if (wikiDisabledFilter !== "default") {
-        return wikiDisabledFilter(page);
+        return wikiDisabledFilter[1](page);
     }
 
     switch (page.split("/")[0]) {

--- a/client/src/components/WikiArticleLink.tsx
+++ b/client/src/components/WikiArticleLink.tsx
@@ -1,7 +1,7 @@
 import { MODIFIERS, ModifierID } from "../game/modifiers";
 import translate, { langJson } from "../game/lang";
 import { Role, roleJsonData } from "../game/roleState.d";
-import { partitionWikiPages, WIKI_CATEGORIES, WikiCategory } from "./Wiki";
+import { partitionWikiPages, WIKI_CATEGORIES, WikiCategory, WikiDisabledFilter } from "./Wiki";
 import "./wiki.css";
 import { getAllRoles } from "../game/roleListState.d"
 
@@ -56,8 +56,13 @@ export function getArticleTitle(page: WikiArticleLink): string {
 export function wikiPageIsEnabled(
     page: WikiArticleLink,
     enabledRoles: Role[],
-    enabledModifiers: ModifierID[]
+    enabledModifiers: ModifierID[],
+    wikiDisabledFilter: WikiDisabledFilter | "default" = "default"
 ): boolean {
+    if (wikiDisabledFilter !== "default") {
+        return wikiDisabledFilter(page);
+    }
+
     switch (page.split("/")[0]) {
         case "role":
             return enabledRoles.map(role => `role/${role}`).includes(page)
@@ -74,7 +79,7 @@ export function wikiPageIsEnabled(
     if (page.startsWith("category/")) {
         return partitionWikiPages(ARTICLES, enabledRoles, enabledModifiers, false)[page.split("/")[1] as any as WikiCategory]
             .filter(p => p !== page)
-            .filter(page => wikiPageIsEnabled(page, enabledRoles, enabledModifiers))
+            .filter(page => wikiPageIsEnabled(page, enabledRoles, enabledModifiers, wikiDisabledFilter))
             .length !== 0
     }
 

--- a/client/src/components/wiki.css
+++ b/client/src/components/wiki.css
@@ -108,3 +108,15 @@
 .role-set-article .masonry-item {
     text-align: center;
 }
+.wiki-disabled-selector {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    justify-content: center;
+    gap: 0.5rem;
+}
+.wiki-disabled-selector > label{
+    background-color: var(--primary-color);
+    border-radius: 0.5rem;
+    padding: 0.25rem 0.5rem;
+}

--- a/client/src/components/wiki.css
+++ b/client/src/components/wiki.css
@@ -3,6 +3,7 @@
     height: 100%;
     max-height: 100%;
     max-width: 100%;
+    min-height: 0;
     display: flex;
     flex-direction: column;
 }
@@ -104,6 +105,9 @@
 .wiki-cover-card {
     width: 80rem;
     min-height: 60vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 .role-set-article .masonry-item {
     text-align: center;
@@ -112,8 +116,9 @@
     display: flex;
     flex-direction: row;
     align-items: stretch;
-    justify-content: center;
+    justify-content: left;
     gap: 0.5rem;
+    flex-wrap: wrap;
 }
 .wiki-disabled-selector > label{
     background-color: var(--primary-color);

--- a/client/src/menu/game/gameScreenContent/wikiMenu.css
+++ b/client/src/menu/game/gameScreenContent/wikiMenu.css
@@ -6,3 +6,6 @@
     min-height: 0;
     flex-grow: 1;
 }
+.wiki-menu .wiki-disabled-selector {
+    padding: 0.5rem;
+}

--- a/client/src/menu/main/standaloneWiki.css
+++ b/client/src/menu/main/standaloneWiki.css
@@ -13,6 +13,7 @@
 .standalone-wiki > div {
     overflow-y: auto;
     width: 100%;
+    height: 100%;
 }
 
 @media only screen and (max-width: 600px) {

--- a/client/src/resources/lang/en_us.json
+++ b/client/src/resources/lang/en_us.json
@@ -1152,6 +1152,10 @@
 
     "hideDisabled": "Hide Disabled",
 
+    "wiki.disabledSelector.gameMode": "Filter by Game Mode",
+    "wiki.disabledSelector.all": "All",
+    "wiki.disabledSelector.default": "Current Game Mode",
+
     "wiki.category.uncategorized": "Other",
     "wiki.category.categories": "Category pages",
     "wiki.category.categories.text": "These are the category pages used to help organize the midnight manual.",

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
### Added
Adds advanced filtering for the Wiki Main Page. See attached images

<img width="3368" height="1834" alt="image" src="https://github.com/user-attachments/assets/7782b51f-8ad6-4097-92e8-72a43721cd08" />
<img width="3364" height="1828" alt="image" src="https://github.com/user-attachments/assets/6369ad2a-fbbe-447d-bd75-6dcaea59b54b" />
<img width="3364" height="1828" alt="image" src="https://github.com/user-attachments/assets/472320ac-2c0b-4b65-87b6-d0ccf0908f0c" />
<img width="1036" height="1824" alt="image" src="https://github.com/user-attachments/assets/5d81f381-60e0-4203-8cf0-2e9f1dfa9772" />
<img width="3368" height="1828" alt="image" src="https://github.com/user-attachments/assets/e81f6b13-697a-4789-865e-1bbc2ceffbce" />

The UI defaults to showing the "Experimental" roles. "Experimental", by default, is the game mode we play with, but a player could theoretically modify it and this would show their modifications rather than what we play with. But, I think that's fine.

### Tested
* In the standalone wiki
* In the wiki overlay in-game
* In the wiki menu in-game
* In the wiki overlay in the lobby
* Long game mode names

### Known issues
* If you update game modes using the game mode editor overlay, your changes won't be reflected in a wiki underneath it. You need to refresh to make that happen. Though, if you're in a lobby and the host edits the current game mode, it *will* update, so that's not an issue.