### PR TITLE
Game Screen Restyling

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+        "label": "Client Run",
+        "command": "pnpm",
+        "args": [
+            "start"
+        ],
+        "options": {
+            "cwd": "${workspaceFolder}/client"
+        }
+    },
+    {
+        "label": "Server Run",
+        "command": "cargo",
+        "args": [
+            "run"
+        ],
+        "options": {
+            "cwd": "${workspaceFolder}/server"
+        }
+    },
+    {
+        "label": "Run",
+        "dependsOn": [
+            "Client Run",
+            "Server Run"
+        ],
+        "problemMatcher": []
+    }
+]
+}

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -1,13 +1,20 @@
-import React, { useEffect, useMemo, useRef, ReactElement, useState, forwardRef } from "react";
+import React, { useEffect, useMemo, useRef, ReactElement, useState, forwardRef, useContext } from "react";
 import "./button.css";
 import ReactDOM from "react-dom/client";
 import { THEME_CSS_ATTRIBUTES } from "..";
+import { CtrlPressedContext } from "../menu/Anchor";
+import Popover from "./Popover";
+import { dropdownPlacementFunction } from "./Select";
+import { WikiArticleLink } from "./WikiArticleLink";
+import WikiArticle from "./WikiArticle";
+import WikiArticleTooltip, { getArticleTooltip } from "./WikiArticleTooltip";
 
 export type ButtonProps<R> = Omit<JSX.IntrinsicElements['button'], 'onClick' | 'ref'> & {
     onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => (R | void | Promise<R | void>)
     highlighted?: boolean,
     pressedChildren?: (result: R) => React.ReactNode
     pressedText?: (result: R) => React.ReactNode
+    tooltip?: JSX.Element | WikiArticleLink
 };
 
 function reconcileProps<R>(props: ButtonProps<R>): JSX.IntrinsicElements['button'] {
@@ -16,6 +23,7 @@ function reconcileProps<R>(props: ButtonProps<R>): JSX.IntrinsicElements['button
     delete newProps.highlighted;
     delete newProps.pressedChildren;
     delete newProps.pressedText;
+    delete newProps.tooltip;
 
     return newProps;
 }
@@ -59,27 +67,69 @@ const RawButton = forwardRef<HTMLButtonElement, ButtonProps<any>>(function RawBu
         if (success === "unclicked" || props.pressedChildren === undefined) return props.children;
         return props.pressedChildren(success) || props.children;
     }, [props, success]);
+    
+    const isCtrlPressed = useContext(CtrlPressedContext) ?? false;
+    
+    const articleTooltip = React.useMemo(() => {
+        if (props.tooltip === undefined) return null;
+        if (typeof props.tooltip !== "string") return props.tooltip;
 
-    return <button {...reconcileProps(props)} ref={ref}
-        className={
-            "button " + (props.className ?? "") + (props.highlighted ? " highlighted" : "")
-        }
-        onClick={async e => {
-            if (props.onClick) {
-                const result = await props.onClick(e);
-                if (result === undefined) return;
-
-                setSuccess(result);
-                if (props.pressedText !== undefined) showPopup(props.pressedText(result))
-
-                if (lastTimeout) clearTimeout(lastTimeout);
-                lastTimeout = setTimeout(() => {
-                    setSuccess("unclicked")
-                    hidePopup();
-                }, POPUP_TIMEOUT_MS);
+        if (isCtrlPressed === true) {
+            return <WikiArticle noLinks={true} article={props.tooltip} className="wiki-article-tooltip" />;
+        } else {
+            const tooltip = getArticleTooltip(props.tooltip);
+            if (tooltip === null) {
+                return null;
             }
-        }}
-    >{children}</button>
+            return <WikiArticleTooltip tooltip={tooltip} />;
+        }
+    }, [isCtrlPressed, props.tooltip]);
+
+    const [hovering, setHovering] = React.useState<boolean>(false);
+
+    const handleFocus = (event: any) => {
+        setHovering(true);
+    };
+
+    const handleUnfocus = (event: any) => {
+        setHovering(false);
+    };
+
+    return <>
+        <button {...reconcileProps(props)} ref={ref}
+            className={
+                "button " + (props.className ?? "") + (props.highlighted ? " highlighted" : "")
+            }
+            onClick={async e => {
+                if (props.onClick) {
+                    const result = await props.onClick(e);
+                    if (result === undefined) return;
+
+                    setSuccess(result);
+                    if (props.pressedText !== undefined) showPopup(props.pressedText(result))
+
+                    if (lastTimeout) clearTimeout(lastTimeout);
+                    lastTimeout = setTimeout(() => {
+                        setSuccess("unclicked")
+                        hidePopup();
+                    }, POPUP_TIMEOUT_MS);
+                }
+            }}
+            onMouseEnter={handleFocus}
+            onMouseLeave={handleUnfocus}
+            onFocus={handleFocus}
+            onBlur={handleUnfocus}
+        >{children}</button>
+        {articleTooltip !== null && <Popover
+            open={hovering && articleTooltip !== null}
+            setOpenOrClosed={setHovering}
+            anchorForPositionRef={ref}
+            onRender={(popover, anchor) => dropdownPlacementFunction(popover, anchor, null)}
+            className="wiki-article-tooltip-popover"
+        >
+            {articleTooltip}
+        </Popover>}
+    </>
 })
 
 export { RawButton };

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -2,12 +2,10 @@ import React, { useEffect, useMemo, useRef, ReactElement, useState, forwardRef, 
 import "./button.css";
 import ReactDOM from "react-dom/client";
 import { THEME_CSS_ATTRIBUTES } from "..";
-import { CtrlPressedContext } from "../menu/Anchor";
-import Popover from "./Popover";
+import { CtrlPressedContext, TooltipContext } from "../menu/Anchor";
 import { dropdownPlacementFunction } from "./Select";
 import { WikiArticleLink } from "./WikiArticleLink";
-import WikiArticle from "./WikiArticle";
-import WikiArticleTooltip, { getArticleTooltip } from "./WikiArticleTooltip";
+import WikiArticleTooltip from "./WikiArticleTooltip";
 
 export type ButtonProps<R> = Omit<JSX.IntrinsicElements['button'], 'onClick' | 'ref'> & {
     onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => (R | void | Promise<R | void>)
@@ -69,67 +67,53 @@ const RawButton = forwardRef<HTMLButtonElement, ButtonProps<any>>(function RawBu
     }, [props, success]);
     
     const isCtrlPressed = useContext(CtrlPressedContext) ?? false;
+    const tooltipContext = useContext(TooltipContext)!;
     
     const articleTooltip = React.useMemo(() => {
         if (props.tooltip === undefined) return null;
         if (typeof props.tooltip !== "string") return props.tooltip;
 
-        if (isCtrlPressed === true) {
-            return <WikiArticle noLinks={true} article={props.tooltip} className="wiki-article-tooltip" />;
-        } else {
-            const tooltip = getArticleTooltip(props.tooltip);
-            if (tooltip === null) {
-                return null;
-            }
-            return <WikiArticleTooltip tooltip={tooltip} />;
-        }
+        return <WikiArticleTooltip article={props.tooltip} />
     }, [isCtrlPressed, props.tooltip]);
 
-    const [hovering, setHovering] = React.useState<boolean>(false);
-
     const handleFocus = (event: any) => {
-        setHovering(true);
+        if (articleTooltip) {
+            tooltipContext.open(
+                articleTooltip,
+                (popover, anchor) => dropdownPlacementFunction(popover, anchor, null),
+                ref
+            )
+        }
     };
 
     const handleUnfocus = (event: any) => {
-        setHovering(false);
+        tooltipContext.close()
     };
 
-    return <>
-        <button {...reconcileProps(props)} ref={ref}
-            className={
-                "button " + (props.className ?? "") + (props.highlighted ? " highlighted" : "")
+    return <button {...reconcileProps(props)} ref={ref}
+        className={
+            "button " + (props.className ?? "") + (props.highlighted ? " highlighted" : "")
+        }
+        onClick={async e => {
+            if (props.onClick) {
+                const result = await props.onClick(e);
+                if (result === undefined) return;
+
+                setSuccess(result);
+                if (props.pressedText !== undefined) showPopup(props.pressedText(result))
+
+                if (lastTimeout) clearTimeout(lastTimeout);
+                lastTimeout = setTimeout(() => {
+                    setSuccess("unclicked")
+                    hidePopup();
+                }, POPUP_TIMEOUT_MS);
             }
-            onClick={async e => {
-                if (props.onClick) {
-                    const result = await props.onClick(e);
-                    if (result === undefined) return;
-
-                    setSuccess(result);
-                    if (props.pressedText !== undefined) showPopup(props.pressedText(result))
-
-                    if (lastTimeout) clearTimeout(lastTimeout);
-                    lastTimeout = setTimeout(() => {
-                        setSuccess("unclicked")
-                        hidePopup();
-                    }, POPUP_TIMEOUT_MS);
-                }
-            }}
-            onMouseEnter={handleFocus}
-            onMouseLeave={handleUnfocus}
-            onFocus={handleFocus}
-            onBlur={handleUnfocus}
-        >{children}</button>
-        {articleTooltip !== null && <Popover
-            open={hovering && articleTooltip !== null}
-            setOpenOrClosed={setHovering}
-            anchorForPositionRef={ref}
-            onRender={(popover, anchor) => dropdownPlacementFunction(popover, anchor, null)}
-            className="wiki-article-tooltip-popover"
-        >
-            {articleTooltip}
-        </Popover>}
-    </>
+        }}
+        onMouseEnter={handleFocus}
+        onMouseLeave={handleUnfocus}
+        onFocus={handleFocus}
+        onBlur={handleUnfocus}
+    >{children}</button>
 })
 
 export { RawButton };

--- a/client/src/components/DetailsSummary.tsx
+++ b/client/src/components/DetailsSummary.tsx
@@ -25,7 +25,7 @@ export default function DetailsSummary(props: Readonly<{
 
     return <div className={"details-summary-container "+(props.className??"")}>
         <div className={"details-summary-summary-container"+(open ? " open" : "")}
-            onClick={() => {
+            onClick={(e) => {
                 if(props.disabled) return;
                 setOpen(!open);
                 if(props.onClick) props.onClick();

--- a/client/src/components/Popover.tsx
+++ b/client/src/components/Popover.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, ReactNode, useContext, useEffect, useMemo, useRef } from "react";
 import ReactDOM from "react-dom/client";
 import { THEME_CSS_ATTRIBUTES } from "..";
-import { AnchorControllerContext, MobileContext } from "../menu/Anchor";
+import { AnchorControllerContext, MobileContext, TooltipContext } from "../menu/Anchor";
 import { MenuControllerContext } from "../menu/game/GameScreen";
 import { GameModeContext } from "./gameModeSettings/GameModesEditor";
 
@@ -91,6 +91,7 @@ export default function Popover<T extends HTMLElement = HTMLElement>(props: Read
     const menuControllerContext = useContext(MenuControllerContext);
     const gameModeContext = useContext(GameModeContext);
     const mobileContext = useContext(MobileContext);
+    const tooltipContext = useContext(TooltipContext);
 
     //open and set position
     useEffect(() => {
@@ -103,7 +104,9 @@ export default function Popover<T extends HTMLElement = HTMLElement>(props: Read
                     <MenuControllerContext.Provider value={menuControllerContext}>
                         <GameModeContext.Provider value={gameModeContext}>
                             <MobileContext.Provider value={mobileContext}>
-                                {props.children}
+                                <TooltipContext.Provider value={tooltipContext}>
+                                    {props.children}
+                                </TooltipContext.Provider>
                             </MobileContext.Provider>
                         </GameModeContext.Provider>
                     </MenuControllerContext.Provider>
@@ -126,7 +129,16 @@ export default function Popover<T extends HTMLElement = HTMLElement>(props: Read
         } else {
             popoverElement.hidden = true;
         }
-    }, [props.children, props.onRender, props.anchorForPositionRef, props.open, popoverRoot, anchorControllerContext, menuControllerContext, gameModeContext, mobileContext]);
+    }, [props.children, props.onRender, props.anchorForPositionRef, props.open, popoverRoot, anchorControllerContext, menuControllerContext, gameModeContext, mobileContext, tooltipContext]);
+
+    // Resize when children change
+    useEffect(() => {
+        setTimeout(() => {
+            if (props.onRender) {
+                props.onRender(popoverRef.current, props.anchorForPositionRef?.current ?? undefined)
+            }
+        })
+    }, [props.anchorForPositionRef, props.children, props.onRender, popoverRef])
 
     //close on click outside
     useEffect(() => {

--- a/client/src/components/StyledText.tsx
+++ b/client/src/components/StyledText.tsx
@@ -1,5 +1,5 @@
 import { marked } from "marked";
-import React, { ReactElement, useCallback, useContext, useEffect, useMemo } from "react";
+import React, { ReactElement, useContext } from "react";
 import ReactDOMServer from "react-dom/server";
 import { find } from "..";
 import translate, { translateChecked } from "../game/lang";
@@ -9,16 +9,14 @@ import DUMMY_NAMES from "../resources/dummyNames.json";
 import { ARTICLES, WikiArticleLink, getArticleLangKey } from "./WikiArticleLink";
 import { MenuControllerContext } from "../menu/game/GameScreen";
 import { Player, UnsafeString } from "../game/gameState.d";
-import { AnchorControllerContext, CtrlPressedContext } from "../menu/Anchor";
+import { AnchorControllerContext, CtrlPressedContext, TooltipContext } from "../menu/Anchor";
 import { setWikiSearchPage } from "./Wiki";
 import { getRoleSetsFromRole, RoleList, translateRoleOutline } from "../game/roleListState.d";
 import { encodeString } from "./ChatMessage";
 import DUMMY_ROLE_LIST from "../resources/dummyRoleList.json";
 import KEYWORD_DATA_JSON_IMPORT from "../resources/keywords.json" with { type: "json" };
-import Popover from "./Popover";
 import { dropdownPlacementFunction } from "./Select";
-import WikiArticleTooltip, { getArticleTooltip } from "./WikiArticleTooltip";
-import WikiArticle from "./WikiArticle";
+import WikiArticleTooltip from "./WikiArticleTooltip";
 
 const KEYWORD_DATA_JSON = KEYWORD_DATA_JSON_IMPORT as { [key: string]: TokenData };
 
@@ -86,15 +84,8 @@ export default function StyledText(props: Readonly<StyledTextProps>): ReactEleme
 
     const jsxString = mapTokensToHtml(tokens, props.noLinks ?? false);
 
-    const shouldHaveToolTip = !(props.noLinks ?? false) && tokens.some(token => token.type === "data" && token.link !== undefined);
-    const [hovering, setHovering] = React.useState<[WikiArticleLink, HTMLElement] | null>(null);
-    const articleToolTip = React.useMemo(() => {
-        if (hovering !== null) {
-            return getArticleTooltip(hovering[0]);
-        }
-        return null;
-    }, [hovering]);
-    
+    const tooltipContext = useContext(TooltipContext)!;
+
     const handleClick = (event: React.MouseEvent<HTMLSpanElement>) => {
         const target = event.target as HTMLElement;
         const anchor = target.closest('a[data-wiki-page]');
@@ -103,7 +94,7 @@ export default function StyledText(props: Readonly<StyledTextProps>): ReactEleme
             const wikiPage = anchor.getAttribute('data-wiki-page') as WikiArticleLink;
             if (wikiPage) {
                 setWikiSearchPage(wikiPage, anchorController, menuController);
-                setHovering(null);
+                tooltipContext.close();
             }
         }
     };
@@ -114,7 +105,11 @@ export default function StyledText(props: Readonly<StyledTextProps>): ReactEleme
         if (anchor) {
             const wikiPage = anchor.getAttribute('data-wiki-page') as WikiArticleLink;
             if (wikiPage) {
-                setHovering([wikiPage, anchor as HTMLElement]);
+                tooltipContext.open(
+                    <WikiArticleTooltip article={wikiPage} />,
+                    (dropdownElement, sourceElement) => dropdownPlacementFunction(dropdownElement, sourceElement, null),
+                    { current: anchor as HTMLElement }
+                )
             }
         }
     };
@@ -123,46 +118,19 @@ export default function StyledText(props: Readonly<StyledTextProps>): ReactEleme
         const target = event.target as HTMLElement;
         const anchor = target.closest('a[data-wiki-page]');
         if (anchor) {
-            setHovering(null);
+            tooltipContext.close();
         }
     };
 
-    const tooltip = useMemo(() => {
-        if (isCtrlPressed === true) {
-            return hovering && <WikiArticle noLinks={true} article={hovering[0]} className="wiki-article-tooltip" />;
-        } else {
-            if (articleToolTip === null) {
-                return null;
-            }
-            return <WikiArticleTooltip tooltip={articleToolTip} />;
-        }
-    }, [articleToolTip, isCtrlPressed, hovering]);
-
-    const dropdownPlacement = useCallback((dropdownElement: HTMLElement) => {
-        dropdownPlacementFunction(dropdownElement, hovering![1], null);
-    }, [hovering, tooltip]);
-
-    return <>
-        <span
-            className={props.className}
-            onClick={handleClick}
-            onMouseOver={handleFocus}
-            onFocus={handleFocus}
-            onMouseOut={handleUnfocus}
-            onBlur={handleUnfocus}
-            dangerouslySetInnerHTML={{__html: jsxString}}>
-        </span>
-        {shouldHaveToolTip && <Popover
-            open={hovering !== null && tooltip !== null}
-            setOpenOrClosed={(open) => {
-                if (!open) setHovering(null);
-            }}
-            onRender={dropdownPlacement}
-            className="wiki-article-tooltip-popover"
-        >
-            {tooltip}
-        </Popover>}
-    </>
+    return <span
+        className={props.className}
+        onClick={handleClick}
+        onMouseOver={handleFocus}
+        onFocus={handleFocus}
+        onMouseOut={handleUnfocus}
+        onBlur={handleUnfocus}
+        dangerouslySetInnerHTML={{__html: jsxString}}>
+    </span>
 }
 
 function mapTokensToHtml(tokens: Token[], noLinks: boolean): string {

--- a/client/src/components/TextAreaDropdown.tsx
+++ b/client/src/components/TextAreaDropdown.tsx
@@ -23,6 +23,7 @@ export function TextDropdownArea(props: Readonly<{
     onSubtract?: () => void,
     onSave: (text: string) => void,
     cantPost: boolean,
+    className?: string,
 
     canPostAs?: PlayerIndex[]
 }>): ReactElement {
@@ -67,7 +68,7 @@ export function TextDropdownArea(props: Readonly<{
 
     return (
         <DetailsSummary
-            className="text-area-dropdown"
+            className={`text-area-dropdown ${props.className || ''}`}
             dropdownArrow={props.dropdownArrow}
             defaultOpen={props.defaultOpen}
             open={props.open}

--- a/client/src/components/WikiArticle.tsx
+++ b/client/src/components/WikiArticle.tsx
@@ -19,6 +19,7 @@ import Popover from "./Popover";
 import { dropdownPlacementFunction } from "./Select";
 import WikiArticleTooltip, { getArticleTooltip } from "./WikiArticleTooltip";
 import { CtrlPressedContext } from "../menu/Anchor";
+import { Button } from "./Button";
 
 function WikiStyledText(props: Omit<StyledTextProps, 'markdown' | 'playerKeywordData'>): ReactElement {
     return <StyledText {...props} markdown={true} playerKeywordData={DUMMY_NAMES_KEYWORD_DATA} roleListKeywordData={DUMMY_ROLE_LIST_KEYWORD_DATA}/>
@@ -221,52 +222,14 @@ function PageButton(props: Readonly<{
     enabledModifiers: ModifierID[],
     wikiDisabledFilter?: [string, WikiDisabledFilter] | "default"
 }>): ReactElement {
-    const isCtrlPressed = useContext(CtrlPressedContext) ?? false;
-
-    const articleTooltip = React.useMemo(() => {
-        if (isCtrlPressed === true) {
-            return <WikiArticle noLinks={true} article={props.page} className="wiki-article-tooltip" />;
-        } else {
-            const tooltip = getArticleTooltip(props.page);
-            if (tooltip === null) {
-                return null;
-            }
-            return <WikiArticleTooltip tooltip={tooltip} />;
-        }
-    }, [isCtrlPressed, props.page]);   
-
-    const buttonRef = useRef<HTMLButtonElement>(null);
-
-    const [hovering, setHovering] = React.useState<boolean>(false);
-
-    const handleFocus = (event: any) => {
-        setHovering(true);
-    };
-
-    const handleUnfocus = (event: any) => {
-        setHovering(false);
-    };
-
-    return <>
-        <button ref={buttonRef} key={props.page} className={wikiPageIsEnabled(props.page, props.enabledRoles, props.enabledModifiers, props.wikiDisabledFilter) ? "" : "keyword-disabled"} 
-            onClick={() => GAME_MANAGER.setWikiArticle(props.page)}
-            onMouseEnter={handleFocus}
-            onMouseLeave={handleUnfocus}
-            onFocus={handleFocus}
-            onBlur={handleUnfocus}
-        >
-            <StyledText noLinks={true}>{getArticleTitle(props.page)}</StyledText>
-        </button>
-        {articleTooltip !== null && <Popover
-            open={hovering && articleTooltip !== null}
-            setOpenOrClosed={setHovering}
-            anchorForPositionRef={buttonRef}
-            onRender={(popover, anchor) => dropdownPlacementFunction(popover, anchor, null)}
-            className="wiki-article-tooltip-popover"
-        >
-            {articleTooltip}
-        </Popover>}
-    </>
+    return <Button 
+        key={props.page}
+        className={wikiPageIsEnabled(props.page, props.enabledRoles, props.enabledModifiers, props.wikiDisabledFilter) ? "" : "keyword-disabled"} 
+        onClick={() => GAME_MANAGER.setWikiArticle(props.page)}
+        tooltip={props.page}
+    >
+        <StyledText noLinks={true}>{getArticleTitle(props.page)}</StyledText>
+    </Button>
 }
 
 

--- a/client/src/components/WikiArticle.tsx
+++ b/client/src/components/WikiArticle.tsx
@@ -1,6 +1,5 @@
-import { ReactElement, ReactNode, useContext, useEffect, useRef, useState } from "react";
+import { ReactElement, ReactNode, useEffect, useRef, useState } from "react";
 import { Role, roleJsonData } from "../game/roleState.d";
-import React from "react";
 import translate, { langText, translateChecked } from "../game/lang";
 import StyledText, { DUMMY_NAMES_KEYWORD_DATA, DUMMY_NAMES_SENDER_KEYWORD_DATA, DUMMY_ROLE_LIST_KEYWORD_DATA, StyledTextProps } from "./StyledText";
 import { ROLE_SETS, RoleList, getAllRoles, getRolesFromRoleSet } from "../game/roleListState.d";
@@ -15,10 +14,6 @@ import { partitionWikiPages, WikiCategory, WikiDisabledFilter } from "./Wiki";
 import { MODIFIERS, ModifierID } from "../game/modifiers";
 import DUMMY_ROLE_LIST from "../resources/dummyRoleList.json";
 import Masonry from "react-responsive-masonry";
-import Popover from "./Popover";
-import { dropdownPlacementFunction } from "./Select";
-import WikiArticleTooltip, { getArticleTooltip } from "./WikiArticleTooltip";
-import { CtrlPressedContext } from "../menu/Anchor";
 import { Button } from "./Button";
 
 function WikiStyledText(props: Omit<StyledTextProps, 'markdown' | 'playerKeywordData'>): ReactElement {

--- a/client/src/components/WikiArticleTooltip.tsx
+++ b/client/src/components/WikiArticleTooltip.tsx
@@ -1,30 +1,42 @@
-import { ReactElement } from "react";
+import { ReactElement, useContext, useMemo } from "react";
 import { translateChecked } from "../game/lang";
 import { ModifierID } from "../game/modifiers";
 import { Role } from "../game/roleState.d";
 import { WikiArticleLink } from "./WikiArticleLink";
 import StyledText, { DUMMY_NAMES_KEYWORD_DATA, DUMMY_ROLE_LIST_KEYWORD_DATA } from "./StyledText";
+import { TooltipContext } from "../menu/Anchor";
+import WikiArticle from "./WikiArticle";
 
 export default function WikiArticleTooltip(props: Readonly<{
-    tooltip: string
+    article: WikiArticleLink
 }>): ReactElement | null {
-    return <div className="wiki-article wiki-article-tooltip">
-        <StyledText
-            noLinks={true}
-            markdown={true}
-            playerKeywordData={DUMMY_NAMES_KEYWORD_DATA}
-            roleListKeywordData={DUMMY_ROLE_LIST_KEYWORD_DATA}
-        >
-            {props.tooltip}
-        </StyledText>
-        <div className="wiki-article-tooltip-footer">
-            {translateChecked("wiki.tooltipHint")}
-        </div>
-    </div>
+    const isCtrlPressed = useContext(TooltipContext)?.ctrlPressed;
+    const articleTooltip = useMemo(() => {
+        return getArticleTooltip(props.article);
+    }, [props.article]);
+
+    return <>
+        {isCtrlPressed
+            ? <WikiArticle noLinks={true} article={props.article} className="wiki-article-tooltip" />
+            : (articleTooltip && <div className="wiki-article wiki-article-tooltip">
+                <StyledText
+                    noLinks={true}
+                    markdown={true}
+                    playerKeywordData={DUMMY_NAMES_KEYWORD_DATA}
+                    roleListKeywordData={DUMMY_ROLE_LIST_KEYWORD_DATA}
+                >
+                    {articleTooltip}
+                </StyledText>
+                <div className="wiki-article-tooltip-footer">
+                    {translateChecked("wiki.tooltipHint")}
+                </div>
+            </div>)
+        }
+    </>
 }
 
 
-export function getArticleTooltip(page: WikiArticleLink): string | null {
+function getArticleTooltip(page: WikiArticleLink): string | null {
     const tooltipText = getArticleTooltipText(page);
     // Max 300 characters
     const shortened = tooltipText?.substring(0, 300);

--- a/client/src/components/chatMessage.css
+++ b/client/src/components/chatMessage.css
@@ -30,6 +30,8 @@
     margin: .1rem;
     margin-left: 0;
     margin-right: 0;
+    padding-left: .25rem;
+    padding-right: .25rem;
     overflow-wrap: anywhere;
     tab-size: 1rem;
 }
@@ -49,7 +51,7 @@
 /* Chat message variants */
 .chat-message.player {
     text-indent: -1rem;
-    padding-left: 1rem;
+    padding-left: 1.25rem;
 }
 .chat-message.mention {
     /* Since it's so blurred, this shadow acts as a highlight overlay. */

--- a/client/src/components/counter.css
+++ b/client/src/components/counter.css
@@ -1,21 +1,16 @@
 .counter {
     display: flex;
     flex-direction: row;
-    background-color: var(--primary-color);
-    border: .13rem solid var(--primary-border-color);
-    border-radius: .25rem;
     justify-content: space-between;
     align-items: center;
 
-    /* margin: 0;
-    padding: 0 .25rem; */
+    padding: 0 .13rem;
 }
 
 .counter-count {
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin: 0 .25rem;
     gap: .25rem;
 }
 

--- a/client/src/components/detailsSummary.css
+++ b/client/src/components/detailsSummary.css
@@ -4,6 +4,13 @@
     justify-content: left;
     align-items: center;
     padding: .13rem;
+    background-color: var(--primary-color);
+    border-radius: 0.27rem;
+}
+.details-summary-summary-container.open {
+    border-bottom: .13rem solid var(--primary-border-shadow-color);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
 }
 .details-summary-container{
     display: flex;

--- a/client/src/components/detailsSummary.css
+++ b/client/src/components/detailsSummary.css
@@ -22,7 +22,7 @@
     border: .13rem solid var(--primary-border-color);
     border-bottom-color: var(--primary-border-shadow-color);
     border-right-color: var(--primary-border-shadow-color);
-    border-radius: 0.5rem;
+    border-radius: 0.4rem;
     /* justify-content: left;
     align-items: center; */
 }

--- a/client/src/components/detailsSummary.css
+++ b/client/src/components/detailsSummary.css
@@ -3,25 +3,15 @@
     flex-direction: row;
     justify-content: left;
     align-items: center;
-
-    background-color: var(--primary-color);
-    border-radius: .5rem;
     padding: .13rem;
-}
-.details-summary-summary-container.open {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-    border-bottom: .13rem solid var(--primary-border-shadow-color);
 }
 .details-summary-container{
     display: flex;
     flex-direction: column;
     margin: .13rem;
     padding: 0;
-    background-color: var(--secondary-color);
+    background-color: var(--background-color);
     border: .13rem solid var(--primary-border-color);
-    border-bottom-color: var(--primary-border-shadow-color);
-    border-right-color: var(--primary-border-shadow-color);
     border-radius: 0.4rem;
     /* justify-content: left;
     align-items: center; */

--- a/client/src/components/gameModeSettings/GameModeSelector.tsx
+++ b/client/src/components/gameModeSettings/GameModeSelector.tsx
@@ -4,7 +4,6 @@ import { AnchorControllerContext } from "../../menu/Anchor";
 import { CopyButton, PasteButton } from "../../components/ClipboardButtons";
 import Icon from "../Icon";
 import { Button } from "../Button";
-import { DragAndDrop } from "../DragAndDrop";
 import { GameModeContext } from "./GameModesEditor";
 import translate from "../../game/lang";
 import "./gameModeSelector.css"
@@ -15,8 +14,6 @@ import Select from "../Select";
 import StyledText from "../StyledText";
 import { strictDeepEqual, useLobbyState } from "../useHooks";
 import FlushInput from "../FlushInput";
-import GAME_MANAGER from "../..";
-import { LobbyState } from "../../game/gameState.d";
 
 type GameModeLocation = {
     name: string,

--- a/client/src/components/gameModeSettings/GameModesEditor.tsx
+++ b/client/src/components/gameModeSettings/GameModesEditor.tsx
@@ -1,8 +1,6 @@
 import { ReactElement, createContext, useCallback, useMemo, useState } from "react";
-import React from "react";
 import { OutlineListSelector } from "./OutlineSelector";
 import { getAllRoles, RoleList, RoleOutline } from "../../game/roleListState.d";
-import translate from "../../game/lang";
 import "./gameModesEditor.css";
 import PhaseTimesSelector from "./PhaseTimeSelector";
 import { PhaseTimes } from "../../game/gameState.d";

--- a/client/src/components/gameModeSettings/OutlineSelector.tsx
+++ b/client/src/components/gameModeSettings/OutlineSelector.tsx
@@ -584,7 +584,7 @@ export function OutlineListSelector(props: Readonly<{
 
     return <section className="graveyard-menu-colors selector-section">
         <div className="selector-section-header">
-            {translate("menu.lobby.roleList")}
+            {translate("menu.lobby.roleList")}: {roleList.length}
             {(props.disabled !== true) && <Button onClick={simplify}>
                 <Icon>filter_list</Icon> {translate("simplify")}
             </Button>}

--- a/client/src/components/textAreaDropdown.css
+++ b/client/src/components/textAreaDropdown.css
@@ -7,7 +7,11 @@
     text-align: left;
     height: fit-content;
     min-height: 2rem;
-    margin: .13rem;
+    margin: 0;
+    border-radius: 0.27rem;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border: none;
     text-wrap: wrap;
     resize: none;
 }
@@ -36,4 +40,19 @@
     flex-wrap: wrap;
     gap: 0.25rem;
     align-items: center;
+}
+
+.text-area-dropdown.stuck-open {
+    border: none;
+    margin: 0;
+}
+.text-area-dropdown.stuck-open .details-summary-container {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+.text-area-dropdown.stuck-open .details-summary-summary-container {
+    border-radius: 0;
+}
+.text-area-dropdown.stuck-open > .details-summary-summary-container > .icon {
+    display: none;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -214,6 +214,7 @@ textarea, .textarea {
     white-space: pre;
     overflow-x: hidden;
     overflow-y: hidden;
+    border-radius: 0.25rem;
 }
 
 *:focus-visible {

--- a/client/src/menu/Anchor.tsx
+++ b/client/src/menu/Anchor.tsx
@@ -364,7 +364,7 @@ function ErrorCard(props: Readonly<{
     return <div className="error-card" onClick={() => props.onClose()}>
         <header>
             {props.error.title}
-            <button className="close">✕</button>
+            <button className="close flush">✕</button>
         </header>
         <div>{props.error.body}</div>
     </div>

--- a/client/src/menu/Anchor.tsx
+++ b/client/src/menu/Anchor.tsx
@@ -17,6 +17,8 @@ import GameModesEditor from "../components/gameModeSettings/GameModesEditor";
 import HostMenu from "./HostMenu";
 import SettingsMenu from "./Settings";
 import NightMessagePopup from "../components/NightMessagePopup";
+import Popover from "../components/Popover";
+import { useLobbyOrGameState } from "../components/useHooks";
 
 const MobileContext = createContext<boolean | undefined>(undefined);
 const CtrlPressedContext = createContext<boolean | undefined>(undefined);
@@ -35,9 +37,20 @@ export type AnchorController = {
     setAccessibilityFontEnabled: (accessibilityFontEnabled: boolean) => void
 }
 
-const AnchorControllerContext = createContext<AnchorController | undefined>(undefined);
+export type TooltipController = {
+    ctrlPressed: boolean,
+    open: (
+        tooltip: JSX.Element,
+        onRender?: (dropdownElement: HTMLElement, sourceElement?: HTMLElement) => void,
+        sourceRef?: React.RefObject<HTMLElement>
+    ) => void,
+    close: () => void,
+}
 
-export { MobileContext, CtrlPressedContext, AnchorControllerContext };
+const AnchorControllerContext = createContext<AnchorController | undefined>(undefined);
+const TooltipContext = createContext<TooltipController | undefined>(undefined);
+
+export { MobileContext, CtrlPressedContext, AnchorControllerContext, TooltipContext };
 
 const MIN_SWIPE_DISTANCE_X = 60;
 const MAX_SWIPE_DISTANCE_Y = 60;
@@ -55,7 +68,39 @@ export default function Anchor(props: Readonly<{
     onMount: (anchorController: AnchorController) => void,
 }>): ReactElement {
     const [mobile, setMobile] = useState<boolean>(false);
+
+    // Tooltip stuff
     const [isCtrlPressed, setIsCtrlPressed] = useState<boolean>(false);
+    const [tooltip, setTooltip] = useState<JSX.Element>(<></>);
+    const [tooltipOnRender, setOnRender] = useState<(dropdownElement: HTMLElement, sourceElement?: HTMLElement) => void>();
+    const [tooltipSourceRef, setSourceRef] = useState<React.RefObject<HTMLElement>>();
+    const [tooltipLastOpened, setLastOpened] = useState<number>(0);
+    const [now, setNow] = useState(Date.now());
+
+    const showTooltip = useMemo(() => !mobile && (now < tooltipLastOpened + 10000), [now, tooltipLastOpened, mobile]);
+
+    useEffect(() => {
+        const interval = setInterval(() => setNow(Date.now()), 100);
+        return () => clearInterval(interval);
+    }, []);
+
+    const openTooltip = useCallback((
+        tooltip: JSX.Element,
+        onRender?: (dropdownElement: HTMLElement, sourceElement?: HTMLElement) => void,
+        sourceRef?: React.RefObject<HTMLElement>
+    ) => {
+        setTooltip(tooltip)
+        // `onRender` is itself a function. Wrap it so React stores the callback
+        // instead of treating it as a state updater and invoking it with the
+        // previous callback value.
+        setOnRender(() => onRender)
+        setSourceRef(sourceRef)
+        setLastOpened(Date.now())
+    }, [])
+
+    const toolTipContext = useMemo(() => {
+        return { ctrlPressed: isCtrlPressed, open: openTooltip, close: () => setLastOpened(0) }
+    }, [isCtrlPressed, openTooltip])
 
     useEffect(() => {
         const onResize = () => {setMobile(window.innerWidth <= MOBILE_MAX_WIDTH_PX)}
@@ -238,10 +283,15 @@ export default function Anchor(props: Readonly<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props])
     
+    const stateType = useLobbyOrGameState(
+        state => state.stateType,
+        ["acceptJoin", "rejectJoin", "rejectStart", "gameInitializationComplete", "startGame", "backToLobby"]
+    )!;
+    
 
     return <MobileContext.Provider value={mobile} >
         <AnchorControllerContext.Provider value={anchorController}>
-            <CtrlPressedContext.Provider value={isCtrlPressed}>
+            <TooltipContext.Provider value={toolTipContext}>
                 <div
                     className="anchor"
                     onTouchStart={(e) => {
@@ -272,7 +322,7 @@ export default function Anchor(props: Readonly<{
                         setTouchCurrent(null)
                     }}
                 >
-                    <Button className="global-menu-button flush" 
+                    <Button className={"global-menu-button " + (stateType === "game" ? "" : "flush")}
                         onClick={() => {
                             if (!globalMenuOpen) {
                                 setGlobalMenuOpen(true)
@@ -287,8 +337,23 @@ export default function Anchor(props: Readonly<{
                         theme={coverCardTheme}
                     >{coverCard}</CoverCard>}
                     {errorCard}
+                    <Popover
+                        open={showTooltip}
+                        setOpenOrClosed={(open) => {
+                            if (open) {
+                                setLastOpened(Date.now())
+                            } else {
+                                setLastOpened(0)
+                            }
+                        }}
+                        anchorForPositionRef={tooltipSourceRef}
+                        onRender={tooltipOnRender}
+                        className="wiki-article-tooltip-popover"
+                    >
+                        {tooltip}
+                    </Popover>
                 </div>
-            </CtrlPressedContext.Provider>
+            </TooltipContext.Provider>
         </AnchorControllerContext.Provider>
     </MobileContext.Provider>
 }

--- a/client/src/menu/GlobalMenu.tsx
+++ b/client/src/menu/GlobalMenu.tsx
@@ -1,4 +1,4 @@
-import React, { JSXElementConstructor, ReactElement, useContext, useEffect, useRef } from 'react';
+import { JSXElementConstructor, ReactElement, useContext, useEffect, useRef } from 'react';
 import "./globalMenu.css";
 import translate from '../game/lang';
 import GAME_MANAGER from '..';

--- a/client/src/menu/game/GameScreen.tsx
+++ b/client/src/menu/game/GameScreen.tsx
@@ -328,11 +328,9 @@ export function ContentTab(props: Readonly<{
     const mobile = useContext(MobileContext)!;
 
     return <div className="content-tab">
-        <div>
-            <StyledText>
-                {props.children}
-            </StyledText>
-        </div>
+        <StyledText>
+            {props.children}
+        </StyledText>
 
         {props.close && (!spectator || mobile) && <Button className="close flush"
             onClick={()=>menuController.closeMenu(props.close as ContentMenu)}

--- a/client/src/menu/game/gameScreen.css
+++ b/client/src/menu/game/gameScreen.css
@@ -32,9 +32,6 @@
     max-height: 100%;
     
     background-color: var(--background-color);
-    border: .13rem solid var(--background-border-color);
-    border-bottom-color: var(--background-border-shadow-color);
-    border-right-color: var(--background-border-shadow-color);
 
     overflow-y: auto;
     overflow-x: hidden;
@@ -42,7 +39,8 @@
 
 .game-screen .content > .panel-handle[data-resize-handle-state="hover"],
 .game-screen .content > .panel-handle[data-resize-handle-state="drag"] {
-    outline: .13rem solid var(--focus-outline-color);
+    outline: .065rem solid var(--focus-outline-color);
+    z-index: 1;
 }
 
 @media only screen and (max-width: 600px) {
@@ -70,15 +68,12 @@
     border-bottom: .13rem solid var(--background-border-shadow-color);
     width: 100%;
     margin: 0;
-    padding: .15rem .15rem;
-    background-color: var(--primary-color);
+    padding: .25rem .5rem;
+    background-color: var(--background-color);
     justify-content: space-between;
     align-items: center;
     user-select: none;
     position: relative;
-}
-.content-tab > div{
-    flex-grow: 1;
 }
 .content-tab > button {
     width: max-content;

--- a/client/src/menu/game/gameScreenContent/AbilityMenu/ControllerSelectionTypes/PlayerListSelectionMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/AbilityMenu/ControllerSelectionTypes/PlayerListSelectionMenu.tsx
@@ -57,6 +57,7 @@ export default function PlayerListSelectionMenu(props: Readonly<{
                 ((props.availableSelection.maxPlayers??Infinity) >= props.availableSelection.availablePlayers.length) && newChoosablePlayers.length !== 0
                 ?
                     <Button
+                        className="flush"
                         onClick={()=>props.onChoose(props.availableSelection.availablePlayers)}
                     >
                         <Icon>select_all</Icon>
@@ -69,6 +70,7 @@ export default function PlayerListSelectionMenu(props: Readonly<{
                 props.selection.length > 0
                 ?
                     <Button
+                        className="flush"
                         onClick={()=>props.onChoose([])}
                     >
                         <Icon>deselect</Icon>

--- a/client/src/menu/game/gameScreenContent/AbilityMenu/ControllerSelectionTypes/RoleListSelectionMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/AbilityMenu/ControllerSelectionTypes/RoleListSelectionMenu.tsx
@@ -56,6 +56,7 @@ export default function RoleListSelectionMenu(props: Readonly<{
                 ((props.availableSelection.maxRoles??Infinity) >= props.availableSelection.availableRoles.length) && newChoosableRoles.length !== 0
                 ?
                     <Button
+                        className="flush"
                         onClick={()=>props.onChoose(props.availableSelection.availableRoles)}
                     >
                         <Icon>select_all</Icon>
@@ -68,6 +69,7 @@ export default function RoleListSelectionMenu(props: Readonly<{
                 props.selection.length > 0
                 ?
                     <Button
+                        className="flush"
                         onClick={()=>props.onChoose([])}
                     >
                         <Icon>deselect</Icon>

--- a/client/src/menu/game/gameScreenContent/AbilityMenu/ControllerSelectionTypes/StringSelectionMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/AbilityMenu/ControllerSelectionTypes/StringSelectionMenu.tsx
@@ -21,13 +21,12 @@ export default function StringSelectionMenu(props: Readonly<{
         title = translateControllerID(props.id);
     }
 
-    return <div>
-        <TextDropdownArea
-            open={true}
-            titleString={title}
-            savedText={props.selection}
-            onSave={(s) => { props.onChoose(s); } }
-            cantPost={cantPost}
-        />    
-    </div>
+    return <TextDropdownArea
+        className="stuck-open"
+        open={true}
+        titleString={title}
+        savedText={props.selection}
+        onSave={(s) => { props.onChoose(s); } }
+        cantPost={cantPost}
+    />    
 }

--- a/client/src/menu/game/gameScreenContent/AbilityMenu/ControllerSelectionTypes/genericListController.css
+++ b/client/src/menu/game/gameScreenContent/AbilityMenu/ControllerSelectionTypes/genericListController.css
@@ -1,4 +1,5 @@
 .generic-list-controller-menu{
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
 }

--- a/client/src/menu/game/gameScreenContent/AbilityMenu/GenericAbilityMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/AbilityMenu/GenericAbilityMenu.tsx
@@ -17,7 +17,6 @@ import {
     IntegerSelection,
     controllerIdToLink
 } from "../../../../game/controllerInput";
-import React from "react";
 import { Button } from "../../../../components/Button";
 import TwoRoleOutlineOptionSelectionMenu from "./ControllerSelectionTypes/TwoRoleOutlineOptionSelectionMenu";
 import GAME_MANAGER from "../../../..";
@@ -41,6 +40,7 @@ import { useGameState, usePlayerState } from "../../../../components/useHooks";
 import { loadSettingsParsed } from "../../../../game/localStorage";
 import { setWikiSearchPage } from "../../../../components/Wiki";
 import { AnchorControllerContext } from "../../../Anchor";
+import { MenuControllerContext } from "../../GameScreen";
 
 type GroupName = `${PlayerIndex}/${Role}` | 
     "syndicate" | 
@@ -277,6 +277,8 @@ type ControllerIconData = {
 
 function ControllerIcon(props: Readonly<{ icon: ControllerIconData }>) {
     const anchorController = useContext(AnchorControllerContext)!;
+    const menuController = useContext(MenuControllerContext)!;
+
 
     const children = useMemo(() => {
         if ("instant" in props.icon) {

--- a/client/src/menu/game/gameScreenContent/AbilityMenu/GenericAbilityMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/AbilityMenu/GenericAbilityMenu.tsx
@@ -314,7 +314,7 @@ function ControllerIcon(props: Readonly<{ icon: ControllerIconData }>) {
     return <Button
         className="flush controller-icon"
         tooltip={tooltip}
-        onClick={() => setWikiSearchPage("standard/controller", anchorController)}
+        onClick={() => setWikiSearchPage("standard/controller", anchorController, menuController)}
     >
         {children}
     </Button>

--- a/client/src/menu/game/gameScreenContent/AbilityMenu/GenericAbilityMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/AbilityMenu/GenericAbilityMenu.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import { ReactElement, useContext, useMemo } from "react";
 import { 
     TwoPlayerOptionSelection, 
     TwoRoleOptionSelection, 
@@ -39,6 +39,8 @@ import BooleanSelectionMenu from "./ControllerSelectionTypes/BooleanSelectionMen
 import "./ControllerSelectionTypes/genericListController.css"
 import { useGameState, usePlayerState } from "../../../../components/useHooks";
 import { loadSettingsParsed } from "../../../../game/localStorage";
+import { setWikiSearchPage } from "../../../../components/Wiki";
+import { AnchorControllerContext } from "../../../Anchor";
 
 type GroupName = `${PlayerIndex}/${Role}` | 
     "syndicate" | 
@@ -236,9 +238,9 @@ function SingleAbilityMenu(props: Readonly<{
                 <div className="generic-ability-menu-tab-summary">
                     <span><StyledText>{controllerIdName}</StyledText></span>
                     <span>
-                        <>{instantIcon ? translate("instant.icon") : ""}</>
-                        <>{nightIcon ? translate("night.icon") : ""}</>
-                        <>{visitIcon ? translate("visit.icon."+visitIcon) : ""}</>
+                        {instantIcon && <ControllerIcon icon={{ instant: true }} />}
+                        {nightIcon && <ControllerIcon icon={{ night: true }} />}
+                        {visitIcon && <ControllerIcon icon={{ visit: visitIcon }} />}
                     </span>
                 </div>
             }
@@ -249,22 +251,71 @@ function SingleAbilityMenu(props: Readonly<{
         </DetailsSummary>
         
     }else{
-        return <>
-            <div className="generic-ability-menu generic-ability-menu-tab-no-summary">
+        return <div className="generic-ability-menu generic-ability-menu-tab-no-summary">
+            <div className="generic-no-summary">
                 <span>
-
                     <StyledText>{controllerIdName}</StyledText>
                 </span>
                 <span>
-                    <>{instantIcon ? translate("instant.icon") : ""}</>
-                    <>{nightIcon ? translate("night.icon") : ""}</>
-                    <>{visitIcon ? translate("visit.icon."+visitIcon) : ""}</>
+                    {instantIcon && <ControllerIcon icon={{ instant: true }} />}
+                    {nightIcon && <ControllerIcon icon={{ night: true }} />}
+                    {visitIcon && <ControllerIcon icon={{ visit: visitIcon }} />}
                 </span>
             </div>
-            <>{inner}</>
-        </>
+            {inner}
+        </div>
     }
-    
+}
+
+type ControllerIconData = {
+    instant: true
+} | {
+    night: true
+} | {
+    visit: "normal" | "abnormal" | "none"
+};
+
+function ControllerIcon(props: Readonly<{ icon: ControllerIconData }>) {
+    const anchorController = useContext(AnchorControllerContext)!;
+
+    const children = useMemo(() => {
+        if ("instant" in props.icon) {
+            return translate("instant.icon");
+        }
+        if ("night" in props.icon) {
+            return translate("night.icon");
+        }
+        if ("visit" in props.icon) {
+            return translate("visit.icon."+props.icon.visit);
+        }
+        return null;
+    }, [props.icon]);
+
+    const tooltip = useMemo(() => {
+        if ("instant" in props.icon) {
+            return <div className="wiki-article wiki-article-tooltip">
+                {translate("wiki.article.standard.controller.tooltip.instant")}
+            </div>;
+        }
+        if ("night" in props.icon) {
+            return <div className="wiki-article wiki-article-tooltip">
+                {translate("wiki.article.standard.controller.tooltip.night")}
+            </div>;
+        }
+        if ("visit" in props.icon) {
+            return <div className="wiki-article wiki-article-tooltip">
+                {translate(`wiki.article.standard.controller.tooltip.visit.${props.icon.visit}`)}
+            </div>;
+        }
+    }, [props.icon]);
+
+    return <Button
+        className="flush controller-icon"
+        tooltip={tooltip}
+        onClick={() => setWikiSearchPage("standard/controller", anchorController)}
+    >
+        {children}
+    </Button>
 }
 
 

--- a/client/src/menu/game/gameScreenContent/AbilityMenu/genericAbilityMenu.css
+++ b/client/src/menu/game/gameScreenContent/AbilityMenu/genericAbilityMenu.css
@@ -6,17 +6,38 @@
 }
 .generic-ability-menu-tab-no-summary {
     display: flex;
+    flex-direction: column;
+    border-bottom: .13rem dotted var(--primary-border-color)
+}
+.generic-ability-menu-tab-no-summary:last-child {
+    border-bottom: none;
+}
+.generic-no-summary {
+    display: flex;
     flex-direction: row;
     justify-content: space-between;
-    align-items: center;
     width: 100%;
-    background-color: var(--secondary-color);
-    border-style: solid;
-    border-color: var(--primary-border-color);
-    border-radius: .4rem;
-    border-width: .13rem;
-    margin-top: 0.25rem;
+    padding: 0 .13rem;
 }
-.generic-ability-menu-tab-no-summary > span{
+.generic-ability-menu-tab-no-summary > div > span{
     display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: .13rem;
+}
+.generic-ability-menu-tab-summary > span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: .13rem;
+    flex-wrap: wrap;
+}
+.controller-icon {
+    padding: 0;
+    margin: 0;
+}
+.generic-ability-menu .text-area-dropdown {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-top: .13rem solid var(--primary-border-color);
 }

--- a/client/src/menu/game/gameScreenContent/AbilityMenu/roleSpecific.css
+++ b/client/src/menu/game/gameScreenContent/AbilityMenu/roleSpecific.css
@@ -1,11 +1,7 @@
 .role-information {
     display: flex;
     flex-direction: row;
-    background-color: var(--primary-color);
-    border: .13rem solid var(--primary-border-color);
-    border-radius: .25rem;
-    padding: .25rem;
-    margin: .13rem;
+    padding: .13rem;
     align-items: center;
     justify-content: space-between;
 }

--- a/client/src/menu/game/gameScreenContent/ChatMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/ChatMenu.tsx
@@ -67,7 +67,7 @@ export default function ChatMenu(): ReactElement {
                 const sendChatController = controllers.get({type: "sendChat", player: id.player});
                 if(sendChatController===null){return null}
 
-                return <div key={JSON.stringify(id)}>
+                return <div className="chat-menu-chat-controller" key={JSON.stringify(id)}>
                     <div key={"header: "+JSON.stringify(id)} className="chat-menu-icons">
                         {!sendChatGroups.includes("all") && translate("noAll.icon")}
                         {sendChatGroups.map((group) => {
@@ -398,8 +398,10 @@ export function ChatTextInput(props: Readonly<{
                 value={chatBoxText}
                 onChange={handleInputChange}
                 onKeyDown={handleInputKeyDown}
+                placeholder={translate("menu.chat.placeHolder")}
             />
             <Button 
+                className="flush"
                 disabled={props.disabled}
                 onClick={sendChatField}
                 aria-label={translate("menu.chat.button.send")}

--- a/client/src/menu/game/gameScreenContent/ChatMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/ChatMenu.tsx
@@ -376,7 +376,11 @@ export function ChatTextInput(props: Readonly<{
         sendingPlayer!==null &&
         sendingPlayer===whispering
     ){
-        return <></>;
+        return <div className="chat-send-section">
+            <StyledText className="chat-message special">
+                {translate("cannotWhisperYourself")}
+            </StyledText>
+        </div>;
     }
 
     return <>

--- a/client/src/menu/game/gameScreenContent/GraveyardMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/GraveyardMenu.tsx
@@ -86,16 +86,19 @@ function EnabledRoles(): ReactElement {
 
     return <div className="graveyard-menu-excludedRoles">
         <DetailsSummary
-            summary={translate("menu.enabledRoles.enabledRoles")}
+            summary={<span className="enabled-roles-summary-span">
+                {translate("menu.enabledRoles.enabledRoles")}
+                <Button
+                    className="flush"
+                    onClick={e => {
+                        e.stopPropagation();
+                        setHideDisabled(hideDisabled => !hideDisabled)
+                    }}
+                >
+                    <Icon>{hideDisabled ? "visibility" : "visibility_off"}</Icon>
+                </Button>
+            </span>}
         >
-            <Button
-                className="flush"
-                onClick={() => setHideDisabled(hideDisabled => !hideDisabled)}
-            >
-                <Icon>{hideDisabled ? "visibility" : "visibility_off"}</Icon>
-                {" "}
-                {hideDisabled ? translate("menu.enabledRoles.showDisabled") : translate("menu.enabledRoles.hideDisabled")}
-            </Button>
             <EnabledRolesDisplay enabledRoles={enabledRoles} hideDisabled={hideDisabled}/>
         </DetailsSummary>
     </div>
@@ -111,16 +114,19 @@ function EnabledModifiers(): ReactElement {
 
     return <div className="graveyard-menu-excludedRoles">
         <DetailsSummary
-            summary={translate("modifiers")}
+            summary={<span className="enabled-roles-summary-span">
+                {translate("modifiers")}
+                <Button
+                    className="flush"
+                    onClick={e => {
+                        e.stopPropagation();
+                        setHideDisabled(hideDisabled => !hideDisabled)
+                    }}
+                >
+                    <Icon>{hideDisabled ? "visibility" : "visibility_off"}</Icon>
+                </Button>
+            </span>}
         >
-            <Button
-                className="flush"
-                onClick={() => setHideDisabled(hideDisabled => !hideDisabled)}
-            >
-                <Icon>{hideDisabled ? "visibility" : "visibility_off"}</Icon>
-                {" "}
-                {hideDisabled ? translate("menu.enabledRoles.showDisabled") : translate("menu.enabledRoles.hideDisabled")}
-            </Button>
             <ModifierSettingsDisplay disabled={true} modifierSettings={modifierSettings} hideDisabled={hideDisabled}/>
         </DetailsSummary>
     </div>

--- a/client/src/menu/game/gameScreenContent/GraveyardMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/GraveyardMenu.tsx
@@ -13,11 +13,16 @@ import { ModifierSettingsDisplay } from "../../../components/gameModeSettings/Mo
 import Icon from "../../../components/Icon";
 
 export default function GraveyardMenu(): ReactElement {
+    const playerCount = useLobbyOrGameState(
+        gameState => gameState.roleList.length,
+        ["roleList"]
+    )!;
+
     return <div className="graveyard-menu graveyard-menu-colors">
         <ContentTab close={ContentMenu.GraveyardMenu}>{translate("menu.gameMode.title")}</ContentTab>
             
         <DetailsSummary
-            summary={translate("menu.lobby.roleList")}
+            summary={translate("menu.lobby.roleList") + ": " + playerCount}
             defaultOpen={true}
         >
             <RoleListDisplay />

--- a/client/src/menu/game/gameScreenContent/PlayerListMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/PlayerListMenu.tsx
@@ -14,8 +14,7 @@ import ChatMessage, { ChatMessageIndex, translateChatMessage } from "../../../co
 import GraveComponent, { translateGraveRole } from "../../../components/grave";
 import { ChatMessageSection, ChatTextInput } from "./ChatMenu";
 import ListMap from "../../../ListMap";
-import { controllerIdToLinkWithPlayer, PlayerListSelection } from "../../../game/controllerInput";
-import Counter from "../../../components/Counter";
+import { controllerIdToLinkWithPlayer } from "../../../game/controllerInput";
 
 export default function PlayerListMenu(): ReactElement {
     const players = useGameState(

--- a/client/src/menu/game/gameScreenContent/PlayerListMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/PlayerListMenu.tsx
@@ -40,9 +40,7 @@ export default function PlayerListMenu(): ReactElement {
 
             {graves.entries().length === 0 || 
                 <>
-                    <div className="dead-players-separator">
-                        <StyledText>{translate("grave.icon")} {translate("graveyard")}</StyledText>
-                    </div>
+                    <StyledText>{translate("grave.icon")} {translate("graveyard")}</StyledText>
                     {graves.entries().map(([index, grave]) => <div key={grave.player} className="player-card-holder"><PlayerCard graveIndex={index} playerIndex={grave.player}/></div>)}
                 </>
             }
@@ -53,9 +51,7 @@ export default function PlayerListMenu(): ReactElement {
                     graves.values().find((grave) => grave.player === player.index) === undefined
                 ).length === 0 || 
                 <>
-                    <div className="dead-players-separator">
-                        <StyledText>{translate("grave.icon")} {translate("graveyard")}</StyledText>
-                    </div>
+                    <StyledText>{translate("grave.icon")} {translate("graveyard")}</StyledText>
                     {players
                         .filter(player => !player.alive)
                         .map(player => <div key={player.index} className="player-card-holder"><PlayerCard playerIndex={player.index}/></div>)

--- a/client/src/menu/game/gameScreenContent/PlayerListMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/PlayerListMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useCallback, useMemo } from "react";
 import translate from "../../../game/lang";
 import GAME_MANAGER from "../../../index";
 import "./playerListMenu.css"
@@ -14,7 +14,7 @@ import ChatMessage, { ChatMessageIndex, translateChatMessage } from "../../../co
 import GraveComponent, { translateGraveRole } from "../../../components/grave";
 import { ChatMessageSection, ChatTextInput } from "./ChatMenu";
 import ListMap from "../../../ListMap";
-import { controllerIdToLinkWithPlayer } from "../../../game/controllerInput";
+import { controllerIdToLinkWithPlayer, PlayerListSelection } from "../../../game/controllerInput";
 import Counter from "../../../components/Counter";
 
 export default function PlayerListMenu(): ReactElement {
@@ -92,11 +92,21 @@ function PlayerCard(props: Readonly<{
         ["roleList"]
     )!;
 
-
-    const controllers = new ListMap(
-        usePlayerState(playerState=>playerState.savedControllers, ["yourAllowedControllers", "yourAllowedController"])??[],
-        (k1, k2)=>controllerIdToLinkWithPlayer(k1)===controllerIdToLinkWithPlayer(k2)
+    const myPlayerIndex = usePlayerState(
+        state => state.myIndex,
+        ["yourPlayerIndex"]
     );
+
+    const rawControllers = usePlayerState(
+        playerState => playerState.savedControllers,
+        ["yourAllowedControllers", "yourAllowedController"]
+    );
+
+    const controllers = useMemo(() => new ListMap(
+        rawControllers ?? [],
+        (k1, k2)=>controllerIdToLinkWithPlayer(k1) === controllerIdToLinkWithPlayer(k2)
+    ), [rawControllers]);
+
     const whisperAsPlayers = controllers.list
         .map(([id, _])=>id.type==="whisper"?id.player:null)
         .filter((x)=>x!==null&&x!==undefined);
@@ -154,6 +164,44 @@ function PlayerCard(props: Readonly<{
 
     const spectator = useSpectator();
 
+    const myNominationControllerId = useMemo(() => {
+        if (myPlayerIndex === undefined) return null;
+        return { type: "nominate" as const, player: myPlayerIndex };
+    }, [myPlayerIndex]);
+
+    const myNominationSelection = useMemo(() => {
+        if (myPlayerIndex === undefined) return null;
+        if (!myNominationControllerId) return null;
+
+        const controller = controllers.get(myNominationControllerId);
+
+        if (!controller) return null;
+        if (controller.selection.type !== "playerList") return null;
+        if (controller.selection.selection.length !== 1) return null;
+
+        return controller.selection.selection[0];
+    }, [controllers, myPlayerIndex, myNominationControllerId]);
+
+    const toggleVoteForThisPlayer = useCallback(() => {
+        if (!myNominationControllerId) return;
+        const currentSelection = myNominationSelection;
+
+        let newSelection: number[];
+        if (currentSelection === props.playerIndex) {
+            newSelection = [];
+        } else {
+            newSelection = [props.playerIndex];
+        }
+
+        GAME_MANAGER.sendControllerInput({
+            id: myNominationControllerId,
+            selection: {
+                type: "playerList",
+                selection: newSelection
+            }
+        });
+    }, [controllers, myPlayerIndex, myNominationControllerId, myNominationSelection]);
+
     return <><div
         className={`player-card`}
         key={props.playerIndex}
@@ -182,16 +230,26 @@ function PlayerCard(props: Readonly<{
         : null}
         
         {
-            phaseState.type === "nomination" && playerAlive &&
-            <Counter
-                max={numVoted}
-                current={numVoted}
-            >
-                {numVoted}
-            </Counter>
+            phaseState.type === "nomination" && playerAlive && (
+                spectator ? (
+                    <>
+                        <Icon>how_to_vote</Icon>
+                        {numVoted}
+                    </>
+                ) : (
+                    <Button
+                        className="flush"
+                        onClick={() => toggleVoteForThisPlayer()}
+                    >
+                        <Icon>how_to_vote</Icon>
+                        {numVoted}
+                    </Button>
+                )
+            ) 
         }
         {spectator ||
-            <Button 
+            <Button
+                className="flush"
                 disabled={whispersDisabled}
                 onClick={()=>{
                     setWhisperChatOpen(!whisperChatOpen);
@@ -212,7 +270,7 @@ function PlayerCard(props: Readonly<{
             const isFilterSet = chatFilter?.type === "playerNameInMessage" && (chatFilter.player === filter);
             
             return <Button 
-                className={"filter"} 
+                className="filter flush"
                 highlighted={isFilterSet}
                 onClick={() => {
                     GAME_MANAGER.updateChatFilter(isFilterSet ? null : filter);

--- a/client/src/menu/game/gameScreenContent/PlayerListMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/PlayerListMenu.tsx
@@ -296,14 +296,13 @@ function PlayerCard(props: Readonly<{
                 if(id.type!=="whisper"){return null}
                 const sendChatController = controllers.get({type: "sendWhisper", player: id.player})!;
 
-                return <>
-                    <ChatTextInput 
-                        key={"input: "+JSON.stringify(id)}
+                return <div className="chat-menu-chat-controller" key={JSON.stringify(id)}>
+                    <ChatTextInput
                         disabled={sendChatController.parameters.grayedOut}
                         whispering={props.playerIndex}
                         controllingPlayer={id.player}
                     />
-                </>
+                </div>
             })
         }
     </div>}

--- a/client/src/menu/game/gameScreenContent/WillMenu.tsx
+++ b/client/src/menu/game/gameScreenContent/WillMenu.tsx
@@ -89,9 +89,7 @@ export default function WillMenu(): ReactElement {
                 }}
             />:null}
 
-            <div className="dead-players-separator">
-                <StyledText>{translate("menu.will.notes.icon")} {translate("menu.will.notes")}</StyledText>
-            </div>
+            <StyledText>{translate("menu.will.notes.icon")} {translate("menu.will.notes")}</StyledText>
 
             <DragAndDrop
                 items={(notes.length === 0 ? [["", 0]] : notes.map((note, i) => [note, i])) as [UnsafeString, number][]}
@@ -129,6 +127,7 @@ export default function WillMenu(): ReactElement {
                 }}
             />
             <Button
+                className="flush"
                 onClick={() => {
                     if(GAME_MANAGER.state.stateType === "game" && GAME_MANAGER.state.clientState.type === "player"){
                         const notes = [...GAME_MANAGER.state.clientState.notes];

--- a/client/src/menu/game/gameScreenContent/chatMenu.css
+++ b/client/src/menu/game/gameScreenContent/chatMenu.css
@@ -36,8 +36,8 @@
     justify-content: left;
     align-items: center;
     padding: 0 .5rem;
-    border-top: .13rem solid var(--primary-border-color);
-    background-color: var(--secondary-color);
+    background-color: var(--background-color);
+    gap: .25rem;
 }
 .chat-whisper-notification {
     display: flex;
@@ -46,13 +46,11 @@
     padding: 0 .25rem;
     gap: .25rem;
     text-align: left;
-    border-top: .13rem solid var(--primary-border-color);
-    background-color: var(--secondary-color);
+    background-color: var(--background-color);
 }
 .chat-send-section {
     display: flex;
     flex-direction: row;
-    border-top: .13rem solid var(--primary-border-color);
     background-color: var(--background-color);
     align-items: stretch;
     height: max-content;
@@ -66,4 +64,13 @@
     width: 100%;
     text-align: left;
     text-wrap: wrap;
+    height: 2rem;
+    flex-grow: 1;
+}
+.chat-menu-chat-controller {
+    border: .13rem solid var(--primary-border-color);
+    padding-top: .13rem;
+    padding-bottom: .13rem;
+    margin: .13rem;
+    border-radius: .25rem;
 }

--- a/client/src/menu/game/gameScreenContent/graveyardMenu.css
+++ b/client/src/menu/game/gameScreenContent/graveyardMenu.css
@@ -25,3 +25,25 @@
 .graveyard-menu-excludedRoles .enabled-roles-button-panel {
     margin: 0;
 }
+.graveyard-menu-excludedRoles .enabled-roles-button-panel {
+    border-radius: 0;
+    border: none;
+}
+.graveyard-menu-excludedRoles .details-summary-summary-container {
+    display: inline-flex;
+}
+.graveyard-menu-excludedRoles .enabled-roles-summary-span {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    flex-grow: 1;
+}
+.graveyard-menu-excludedRoles .details-summary-summary-container button {
+    visibility: hidden;
+    margin: 0;
+    padding: 0;
+}
+.graveyard-menu-excludedRoles .details-summary-summary-container.open button {
+    visibility: visible;
+}

--- a/client/src/menu/game/gameScreenContent/playerListMenu.css
+++ b/client/src/menu/game/gameScreenContent/playerListMenu.css
@@ -76,7 +76,8 @@
 }
 
 .player-card .chat-notification{
-    font-size: 0.83rem;
+    font-size: 0.5rem;
+    font-weight: bold;
     height: 0.83rem;
     aspect-ratio: 1;
     background-color: var(--primary-color);

--- a/client/src/menu/game/gameScreenContent/playerListMenu.css
+++ b/client/src/menu/game/gameScreenContent/playerListMenu.css
@@ -13,6 +13,9 @@
     display: flex;
     flex-direction: column;
 }
+.player-list-menu .player-list > span {
+    padding: .13rem 0;
+}
 
 
 

--- a/client/src/menu/game/gameScreenContent/playerListMenu.css
+++ b/client/src/menu/game/gameScreenContent/playerListMenu.css
@@ -63,6 +63,7 @@
 .player-list-menu .player-list-chat-section{
     border-top: var(--primary-border-color) solid .13rem;
     border-bottom: var(--primary-border-color) solid .13rem;
+    background-color: var(--background-color);
 }
 .player-list-menu .player-list-chat-message-section{
     height: 10rem;

--- a/client/src/menu/game/headerMenu.css
+++ b/client/src/menu/game/headerMenu.css
@@ -79,6 +79,7 @@
 } 
 .chat-notification{
     font-size: 0.83rem;
+    font-weight: bold;
     height: 0.83rem;
     aspect-ratio: 1;
     background-color: var(--primary-color);

--- a/client/src/menu/game/headerMenu.css
+++ b/client/src/menu/game/headerMenu.css
@@ -96,7 +96,7 @@
     left: .5rem;
     top: .5rem;
     font-size: 1.25rem;
-    padding: .13rem calc(.5rem - .13rem);
+    padding: .25rem calc(.5rem - .13rem);
 }
 /* .header-menu .fast-forward-button-div > button:first-of-type {
     margin: 0;

--- a/client/src/menu/globalMenu.css
+++ b/client/src/menu/globalMenu.css
@@ -4,7 +4,7 @@
     display: flex;
     flex-direction: column;
     right: 0.38rem;
-    top: 2.75rem;
+    top: 3.25rem;
     height: fit-content;
     min-width: fit-content;
     box-shadow: 0 0 .5rem #0007;

--- a/client/src/menu/lobby/LobbyChatMenu.tsx
+++ b/client/src/menu/lobby/LobbyChatMenu.tsx
@@ -27,6 +27,7 @@ export default function LobbyChatMenu(props: Readonly<{spectator: boolean}>): Re
             }}
         >
             <h2>
+                <Icon size="small">chat</Icon>
                 {translate("menu.chat.title")}
                 {chatNotification && <div className="chat-notification highlighted">!</div>}
             </h2>

--- a/client/src/menu/lobby/LobbyMenu.tsx
+++ b/client/src/menu/lobby/LobbyMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { ReactElement, useContext, useEffect, useMemo, useState } from "react";
 import GAME_MANAGER, { DEV_ENV } from "../../index";
 import LobbyPlayerList from "./LobbyPlayerList";
 import "./lobbyMenu.css";

--- a/client/src/menu/lobby/LobbyPlayerList.tsx
+++ b/client/src/menu/lobby/LobbyPlayerList.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useRef, useState } from "react";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
 import translate from "../../game/lang";
 import GAME_MANAGER from "../../index";
 import "./lobbyMenu.css";
@@ -59,16 +59,6 @@ export default function LobbyPlayerList(): ReactElement {
         ["playersHost", "playersLostConnection", "lobbyClients", "playersReady", "hostData", "gamePlayers"]
     ) ?? [];
 
-    const host = useLobbyOrGameState(
-        state => {
-            if (state.stateType === "lobby")
-                return state.players.get(state.myId!)?.ready === "host"
-            else
-                return state.host !== null
-        },
-        ["playersHost", "lobbyClients", "yourId", "playersReady", "hostData"]
-    )!;
-
     return <section className="player-list-menu-colors selector-section lobby-player-list-section">
         <div className="lobby-player-list">
             <ol>
@@ -99,9 +89,6 @@ function LobbyPlayerListPlayer(props: Readonly<{ player: PlayerDisplayData }>): 
         ["playersHost", "lobbyClients", "yourId", "playersReady", "hostData"]
     )!;
 
-    const [renameOpen, setRenameOpen] = useState(false);
-    const renameButtonRef = useRef<HTMLButtonElement>(null);
-
     return <li key={props.player.id} className={props.player.connection==="connected" ? "" : "keyword-dead"}>
         <div>
             {props.player.connection === "couldReconnect" && <Icon>signal_cellular_connected_no_internet_4_bar</Icon>}
@@ -127,6 +114,10 @@ function LobbyPlayerListPlayer(props: Readonly<{ player: PlayerDisplayData }>): 
 
 function LobbyPlayerListPlayerRename(props: Readonly<{ player: PlayerDisplayData }>): ReactElement {
     const [playerName, setPlayerName] = useState(props.player.name ?? "");
+
+    useEffect(() => {
+        setPlayerName(props.player.name ?? "BUG")
+    }, [props.player.name])
     
     return <FlushInput 
         className="lobby-player-list-player-rename"

--- a/client/src/menu/lobby/LobbyPlayerList.tsx
+++ b/client/src/menu/lobby/LobbyPlayerList.tsx
@@ -1,13 +1,10 @@
-import React, { ReactElement, useEffect, useRef, useState } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import translate from "../../game/lang";
 import GAME_MANAGER from "../../index";
 import "./lobbyMenu.css";
 import { ClientConnection } from "../../game/gameState.d";
 import Icon from "../../components/Icon";
 import { useLobbyOrGameState } from "../../components/useHooks";
-import { Button, RawButton } from "../../components/Button";
-import Popover from "../../components/Popover";
-import { selectPlacementFunction } from "../../components/Select";
 import StyledText from "../../components/StyledText";
 import { encodeString } from "../../components/ChatMessage";
 import FlushInput from "../../components/FlushInput";

--- a/client/src/menu/lobby/lobbyChatMenu.css
+++ b/client/src/menu/lobby/lobbyChatMenu.css
@@ -32,7 +32,13 @@
     justify-content: space-between;
 }
 
-.lobby-chat-menu-header > h2 {
+.lobby-chat-menu-header > div {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.lobby-chat-menu-header  h2 {
     padding-right: 1.5rem;
     display: flex;
     flex-direction: row;
@@ -40,7 +46,7 @@
     align-items: center;
 }
 
-.lobby-chat-menu-header > h2 > .chat-notification {
+.lobby-chat-menu-header  h2 > .chat-notification {
     position: unset;
 }
 
@@ -48,4 +54,5 @@
     height: 20em;
     overflow: auto;
     flex-grow: 1;
+    border-bottom: .13rem solid var(--primary-border-color);
 }

--- a/client/src/resources/lang/en_us.json
+++ b/client/src/resources/lang/en_us.json
@@ -1557,6 +1557,11 @@
     "wiki.article.standard.controller.title":"Controller",
     "wiki.article.standard.controller.title:var.0":"Controllers",
     "wiki.article.standard.controller.text":"Controllers are elements of the ability menu that are used to control abilities.\n\nControllers have reminder icons.\n - 🌙: The ability happens at night.\n - ⚡: The ability happens the instant the controller value is changed.\n - 🧭: The controller causes visits normally (The player with the controller visits all players chosen).\n - ❓: The controller causes visits in an unusual way, check the manual to see how the ability visits function.\n\n Controllers have many types:\n- Player List: An ordered list of player dropdowns with a maximum length (Roles like detective use this controller type with a maximum length of 1)\n- Two Players: Must choose 0 or 2 players\n- Role list: An ordered list of roles with a maximum (Imposter disguise controller uses this with maximum of 1).\n- Two Roles: Must choose 0 or 2 roles.\n- Checkbox: Yes or no (Veteran rampage uses this).\n- Button: A single button press (Mayor enfranchise uses this)\n- Text Box: (Forger and Reporter use this).\n- Outline List: A depiction of the outline list, with buttons to choose multiple of them (Auditor uses this).\n Options: A list of options with names in a dropdown.\n- Kira: used only for Kira.",
+    "wiki.article.standard.controller.tooltip.instant":"⚡: The ability happens the instant the controller value is changed.",
+    "wiki.article.standard.controller.tooltip.night":"🌙: The ability happens at night.",
+    "wiki.article.standard.controller.tooltip.visit.normal":"🧭: The controller causes visits normally (The player with the controller visits all players chosen).",
+    "wiki.article.standard.controller.tooltip.visit.abnormal":"❓: The controller causes visits in an unusual way, check the manual to see how the ability visits function.",
+    "wiki.article.standard.controller.tooltip.visit.none":"⛔: The controller does not cause any visits.",
 
     "wiki.article.modifier.obscuredGraves.title":"Obscured Graves",
     "wiki.article.modifier.obscuredGraves.text":"Obscured Graves is a game modifier that makes it so all graves are obscured.",

--- a/client/src/resources/lang/en_us.json
+++ b/client/src/resources/lang/en_us.json
@@ -116,6 +116,7 @@
 
     "playerIsWhisperingToPlayer": "\\0 is whispering to \\1.",
     "cancelWhisper": "Cancel whisper",
+    "cannotWhisperYourself": "You can't whisper yourself.",
 
     "button.clear": "Clear",
 


### PR DESCRIPTION
Restyles the game screen to match the new style of the lobby screen. However, unlike that PR, this doesn't make major modifications to the layout.

Changes:
* Chat messages now have padding on the side so they don't rub up against the edge of the chat menu.
* DetailsSummaries that cannot be closed now do not appear like they can.
* Counters and most role-specific menus are now flush
* Many more (all?) icon-only buttons are flush
* Removed bordering borders wherever it added noise
* Game screen menu headers are now left aligned
* Drag handles are now centered
* Controller icons now have tooltips and link to the controller page when clicked
* Brought back the placeholder text for the chat box
* "Hide Disabled" buttons are now in headers where possible
* The nomination count in the player list is now a button you can use to nominate that player
* Chat text box is shorter
* Chat notifications are bolder and properly sized for all bubble sizes
* Lobby chat menu now has a chat icon
Meta:
* Adds new "Client Run", "Server Run", and "Run" tasks to the VSCode configuration so you can save time starting both the server and client by using the command palette
* Tooltips are now intrinsic to buttons, so it's easier to make any button show a tooltip. This PR only uses it for the controller icons, but it may make sense to expand its usage.